### PR TITLE
Add support for GIT_EDITOR containing quotes

### DIFF
--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Tuple
-from subprocess import run, CalledProcessError
+from subprocess import run, CalledProcessError, PIPE
 from pathlib import Path
 import textwrap
 import sys
@@ -57,8 +57,13 @@ def local_commits(repo: Repository, tip: Commit) -> Tuple[Commit, List[Commit]]:
 
 def edit_file(path: Path) -> bytes:
     try:
+        editor = (
+            run(["git", "var", "GIT_EDITOR"], check=True, cwd=path.parent, stdout=PIPE)
+            .stdout.decode("utf-8")
+            .rstrip()
+        )
         run(
-            ["bash", "-c", f"exec $(git var GIT_EDITOR) {shlex.quote(path.name)}"],
+            ["bash", "-c", f"exec {editor} {shlex.quote(path.name)}"],
             check=True,
             cwd=path.parent,
         )


### PR DESCRIPTION
The subshell `$(...)` inside `exec` inside `bash -c` will not work when
`GIT_EDITOR` contains quoted arguments. For example:

    $ GIT_EDITOR='vim -u "myvimrc"' git revise -i
    E282: Cannot read from ""myvimrc""

Note the double quoting in the error message. So the quotes around the
filename were considered literal.

If you need some white spaces inside the quoted part, things get
weirder:

    $ GIT_EDITOR='vim -u "myvim rc"' git revise -i
    2 files to edit
    E282: Cannot read from ""myvim"

Now `"myvim` and `rc"` are considered two different arguments.

The proposed change removes the subshell in favor of getting the
GIT_EDITOR contents in a separate step. That way, all the quoting and
spacing work as expected.

Fixes #30