### PR TITLE
Add support for git config core.commentchar

### DIFF
--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -205,6 +205,15 @@ class Repository:
             return prog.stdout[:-1]
         return prog.stdout
 
+    def config(self, setting: str, default: Optional[bytes] = None) -> bytes:
+        cwd = getattr(self, "workdir", None)
+        cmd = ["git", "config", setting]
+        prog = run(cmd, cwd=cwd, check=False, stdout=PIPE)
+
+        if prog.returncode == 1:
+            return default if default is not None else b""
+        return prog.stdout[:-1]
+
     def __enter__(self) -> "Repository":
         return self
 


### PR DESCRIPTION
This branch makes sure git revise uses the core.commentchar config in the editor, and this fixes #22.
It uses the comment char as set in the config, defaults to `#` if not present, and picks the comment char from a set of options when `auto` is set, just as git does (failing with the same message when no suitable char is found).

I'm no Python programmer, and thus not aware of idiomatic Python usage. Feel free to comment on that. Furthermore, I hope I got the `bytes` vs `str` correct.