### PR TITLE
Support revise.autosquash

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,3 +120,7 @@ man_pages = [
 ]
 
 # -- Extension configuration -------------------------------------------------
+
+
+def setup(app):
+    app.add_object_type("gitconfig", "gitconfig", objname="git config value")

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -62,7 +62,7 @@ Main modes of operation
    Rather than applying staged changes to <target>, edit a todo list of
    actions to perform on commits after <target>. See :ref:`interactive-mode`.
 
-.. option:: --autosquash
+.. option:: --autosquash, --no-autosquash
 
    Rather than directly applying staged changes to <target>, automatically
    perform fixup or squash actions marked with ``fixup!`` or ``squash!``
@@ -75,6 +75,10 @@ Main modes of operation
 
    This option can be combined with :option:`--interactive` to modify the
    generated todos before they're executed.
+
+   If the :option:`--autosquash` option is enabled by default using a
+   configuration variable, the option :option:`--no-autosquash` can be used
+   to override and disable this setting. See :ref:`configuration`.
 
 .. option:: -c, --cut
 
@@ -103,6 +107,23 @@ Main modes of operation
 .. option:: --version
 
    Print version information and exit.
+
+
+.. _configuration:
+
+CONFIGURATION
+=============
+
+.. option:: revise.autoSquash
+
+   If set to true enable :option:`--autosquash` option by default. Only
+   applicable with :option:`--interactive`.
+   This setting overrides :option:`rebase.autoSquash`.
+
+.. option:: rebase.autoSquash
+
+   When :option:`revise.autoSquash` is unset, standard git configuration
+   ``rebase.autoSquash`` is used as a fallback.
 
 
 CONFLICT RESOLUTION

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -114,16 +114,13 @@ Main modes of operation
 CONFIGURATION
 =============
 
-.. option:: revise.autoSquash
+Configuration is managed by :manpage:`git-config(1)`.
 
-   If set to true enable :option:`--autosquash` option by default. Only
-   applicable with :option:`--interactive`.
-   This setting overrides :option:`rebase.autoSquash`.
+.. gitconfig:: revise.autoSquash
 
-.. option:: rebase.autoSquash
-
-   When :option:`revise.autoSquash` is unset, standard git configuration
-   ``rebase.autoSquash`` is used as a fallback.
+   If set to true, imply :option:`--autosquash` whenever :option:`--interactive`
+   is specified. Overridden by :option:`--no-autosquash`. Defaults to false. If
+   not set, the value of ``rebase.autoSquash`` is used instead.
 
 
 CONFLICT RESOLUTION

--- a/git-revise.1
+++ b/git-revise.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "GIT-REVISE" "1" "Aug 05, 2019" "0.4.2" "git-revise"
+.TH "GIT-REVISE" "1" "Sep 27, 2019" "0.4.2" "git-revise"
 .SH NAME
 git-revise \- Efficiently update, split, and rearrange git commits
 .
@@ -67,7 +67,7 @@ Ignore staged changes in the index.
 .INDENT 0.0
 .TP
 .B \-\-reauthor
-Reset target commit\(aqs author to the current user.
+Reset target commit’s author to the current user.
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -83,7 +83,7 @@ actions to perform on commits after <target>. See \fI\%INTERACTIVE MODE\fP\&.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B \-\-autosquash
+.B \-\-autosquash, \-\-no\-autosquash
 Rather than directly applying staged changes to <target>, automatically
 perform fixup or squash actions marked with \fBfixup!\fP or \fBsquash!\fP
 between <target> and the current \fBHEAD\fP\&. For more information on what
@@ -94,7 +94,11 @@ These commits are usually created with \fBgit commit \-\-fixup=<commit>\fP or
 line of its commit message.
 .sp
 This option can be combined with \fI\%\-\-interactive\fP to modify the
-generated todos before they\(aqre executed.
+generated todos before they’re executed.
+.sp
+If the \fI\%\-\-autosquash\fP option is enabled by default using a
+configuration variable, the option \fI\%\-\-no\-autosquash\fP can be used
+to override and disable this setting. See \fI\%CONFIGURATION\fP\&.
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -102,15 +106,15 @@ generated todos before they\(aqre executed.
 Interactively select hunks from <target>. The chosen hunks are split into
 a second commit immediately after the target.
 .sp
-After splitting is complete, both commit\(aqs messages are edited.
+After splitting is complete, both commits’ messages are edited.
 .sp
-See the "Interactive Mode" section of \fBgit\-add(1)\fP to learn how
+See the “Interactive Mode” section of \fBgit\-add(1)\fP to learn how
 to operate this mode.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B \-e, \-\-edit
-After applying staged changes, edit <target>\(aqs commit message.
+After applying staged changes, edit <target>’s commit message.
 .sp
 This option can be combined with \fI\%\-\-interactive\fP to allow editing
 of commit messages within the todo list. For more information on, see
@@ -127,6 +131,16 @@ paragraphs.
 .TP
 .B \-\-version
 Print version information and exit.
+.UNINDENT
+.SH CONFIGURATION
+.sp
+Configuration is managed by \fBgit\-config(1)\fP\&.
+.INDENT 0.0
+.TP
+.B revise.autoSquash
+If set to true, imply \fI\%\-\-autosquash\fP whenever \fI\%\-\-interactive\fP
+is specified. Overridden by \fI\%\-\-no\-autosquash\fP\&. Defaults to false. If
+not set, the value of \fBrebase.autoSquash\fP is used instead.
 .UNINDENT
 .SH CONFLICT RESOLUTION
 .sp
@@ -146,7 +160,7 @@ A successful \fBgit revise\fP will add a single entry to the reflog,
 allowing it to be undone with \fBgit reset @{1}\fP\&. Unsuccessful \fBgit
 revise\fP commands will leave your repository largely unmodified.
 .sp
-No marge commits may occur between the target commit and \fBHEAD\fP, as
+No merge commits may occur between the target commit and \fBHEAD\fP, as
 rewriting them is not supported.
 .sp
 See \fBgit\-rebase(1)\fP for more information on the implications of
@@ -156,7 +170,7 @@ modifying history on a repository that you share.
 \fBgit revise\fP supports an interactive mode inspired by the
 interactive mode of \fBgit\-rebase(1)\fP\&.
 .sp
-This mode is started with the last commit you want to retain "as\-is":
+This mode is started with the last commit you want to retain “as\-is”:
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -230,18 +244,18 @@ Use the given commit as\-is in history. When applied to the generated
 .INDENT 0.0
 .TP
 .B fixup
-Add the commit\(aqs changes into the previous commit, discarding it\(aqs commit
+Add the commit’s changes into the previous commit, discarding its commit
 message.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B squash
-Like fuse, but also open an editor to merge the commit\(aqs messages.
+Like fixup, but also open an editor to merge the commits’ messages.
 .UNINDENT
 .INDENT 0.0
 .TP
 .B reword
-Open an eitor to modify the commit message.
+Open an editor to modify the commit message.
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -249,9 +263,9 @@ Open an eitor to modify the commit message.
 Interactively select hunks from the commit. The chosen hunks are split
 into a second commit immediately after it.
 .sp
-After splitting is complete, both commit\(aqs messages are edited.
+After splitting is complete, both commits’ messages are edited.
 .sp
-See the "Interactive Mode" section of \fBgit\-add(1)\fP to learn how
+See the “Interactive Mode” section of \fBgit\-add(1)\fP to learn how
 to operate this mode.
 .UNINDENT
 .SH REPORTING BUGS

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -205,9 +205,20 @@ class Repository:
             return prog.stdout[:-1]
         return prog.stdout
 
-    def config(self, setting: str, default: bytes = b"") -> bytes:
+    def config(
+        self,
+        setting: str,
+        config_type: Optional[str] = None,
+        default: bytes = b"",
+    ) -> bytes:
+        cmd = []
+        if config_type is not None:
+            # git version >= 2.19:
+            # cmd += ["--type", config_type]
+            # git version < 2.19:
+            cmd += ["--" + config_type]
         try:
-            return self.git("config", setting)
+            return self.git("config", "--get", *cmd, setting)
         except CalledProcessError:
             return default
 

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -206,10 +206,7 @@ class Repository:
         return prog.stdout
 
     def config(
-        self,
-        setting: str,
-        config_type: Optional[str] = None,
-        default: bytes = b"",
+        self, setting: str, config_type: Optional[str] = None, default: bytes = b""
     ) -> bytes:
         cmd = []
         if config_type is not None:


### PR DESCRIPTION
This PR builds on top of my other PR (#38 support core.commentchar) which introduced the `repo.config` function. Hence the commentchar things in the diffs.

Just like my other pull request, I'm quite new to python, its ecosystem and best practices, so I'm happy to learn from your feedback.

Some observations/questions from my side:

I noticed that git-revise.1 (the compiled man page) is in git, but is outdated.
Should this file be in git? If yes, should I commit it as well?

Now you can call `git revise -i --autosquash --no-autosquash`. This behaves the same as `git revise -i --autosquash --no-autosquash`, in that it does _not_ autosquash. The options can be made mutually exclusive, but since `git rebase` accepts them, I tend to leave it like it is.

I'm not really happy with the unit tests, as they check a simple function by invoking the entire application.
Furthermore, I found no way to ignore `git config --global` settings (other than unsetting it at the start of the unit test, and re-set it afterwards; which is highly undesirable in a unit test), so one unit test is already a flawed in that respect. Any hints on that?

Fixes #10