### PR TITLE
Include license in PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
"A copy of the license and copyright notice must be included with the software."