### PR TITLE
Update documentation of to-do list index command

### DIFF
--- a/docs/man.rst
+++ b/docs/man.rst
@@ -178,7 +178,8 @@ index>`` entry will also be present.
 
 These commits may be re-ordered to change the order they appear in history.
 In addition, the ``pick`` and ``index`` commands may be replaced to modify
-their behaviour.
+their behaviour. If present, then ``index`` commands must be at the bottom
+of the list, i.e. they can not be followed by non-index commands.
 
 If :option:`-e` was specified, the full commit message will be included, and
 each command line will begin with a ``++``. Any changes made to the commit
@@ -208,24 +209,23 @@ The following commands are supported in all interactive modes:
    Index lines must come last in the file.
 
    .. note:
-      Commits deleted from the to-do list are treated as an index action. To
-      completely discard changes, additionally use :manpage:`git-reset(1)` to
-      discard the changes to the index.
+      Commits may not be deleted or dropped from the to-do list. To remove a
+      commit, mark it as an index action, and use :manpage:`git-reset(1)` to
+      discard changes.
 
 .. describe:: pick
 
    Use the given commit as-is in history. When applied to the generated
    ``index`` entry, the commit will have the message ``<git index>``.
 
+.. describe:: squash
+
+   Add the commit's changes into the previous commit and open an editor
+   to merge the commits' messages.
 
 .. describe:: fixup
 
-   Add the commit's changes into the previous commit, discarding its commit
-   message.
-
-.. describe:: squash
-
-   Like fixup, but also open an editor to merge the commits' messages.
+   Like squash, but discard this commit's message.
 
 .. describe:: reword
 

--- a/git-revise.1
+++ b/git-revise.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "GIT-REVISE" "1" "Nov 11, 2019" "0.5.1" "git-revise"
+.TH "GIT-REVISE" "1" "Dec 11, 2019" "0.5.1" "git-revise"
 .SH NAME
 git-revise \- Efficiently update, split, and rearrange git commits
 .
@@ -200,7 +200,8 @@ index 672841329981 <git index>
 .sp
 These commits may be re\-ordered to change the order they appear in history.
 In addition, the \fBpick\fP and \fBindex\fP commands may be replaced to modify
-their behaviour.
+their behaviour. If present, then \fBindex\fP commands must be at the bottom
+of the list, i.e. they can not be followed by non\-index commands.
 .sp
 If \fI\%\-e\fP was specified, the full commit message will be included, and
 each command line will begin with a \fB++\fP\&. Any changes made to the commit
@@ -243,14 +244,14 @@ Use the given commit as\-is in history. When applied to the generated
 .UNINDENT
 .INDENT 0.0
 .TP
-.B fixup
-Add the commit\(aqs changes into the previous commit, discarding its commit
-message.
+.B squash
+Add the commit\(aqs changes into the previous commit and open an editor
+to merge the commits\(aq messages.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B squash
-Like fixup, but also open an editor to merge the commits\(aq messages.
+.B fixup
+Like squash, but discard this commit\(aqs message.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -151,20 +151,26 @@ def edit_todos_msgedit(repo: Repository, todos: List[Step]) -> List[Step]:
         Commands:
          p, pick <commit> = use commit
          r, reword <commit> = use commit, but edit the commit message
-         f, fixup <commit> = use commit, but fuse changes into previous commit
-         s, squash <commit> = like fixup, but also edit the commit message
+         s, squash <commit> = use commit, but meld into previous commit
+         f, fixup <commit> = like "squash", but discard this commit's message
          c, cut <commit> = interactively split commit into two smaller commits
-         i, index <commit> = leave commit changes unstaged
+         i, index <commit> = leave commit changes staged
 
-        Each command is prefixed by a '++' marker, and followed by the complete
-        commit message.
+        Each command block is prefixed by a '++' marker, followed by the command to
+        run, the commit hash and after a newline the complete commit message until
+        the next '++' marker or the end of the file.
 
-        Commit messages will be reworded to match the text following them
-        before the command is performed.
+        Commit messages will be reworded to match the provided message before the
+        command is performed.
 
-        If a command is removed, it will be treated like an 'index' line.
+        These blocks are executed from top to bottom. They can be re-ordered and
+        their commands and messages can be changed, however the number of blocks
+        must remain identical.
+        If present, then index command blocks must be at the bottom of the list,
+        i.e. they can not be followed by non-index commands. Also, their messages
+        are lost.
 
-        However, if you remove everything, these changes will be aborted.
+        If you remove everything, the revising process will be aborted.
         """,
     )
 
@@ -200,16 +206,19 @@ def edit_todos(repo: Repository, todos: List[Step], msgedit=False) -> List[Step]
         Commands:
          p, pick <commit> = use commit
          r, reword <commit> = use commit, but edit the commit message
-         f, fixup <commit> = use commit, but fuse changes into previous commit
-         s, squash <commit> = like fixup, but also edit the commit message
+         s, squash <commit> = use commit, but meld into previous commit
+         f, fixup <commit> = like "squash", but discard this commit's log message
          c, cut <commit> = interactively split commit into two smaller commits
-         i, index <commit> = leave commit changes unstaged
+         i, index <commit> = leave commit changes staged
 
-        These lines can be re-ordered; they are executed from top to bottom.
+        These lines are executed from top to bottom. They can be re-ordered and
+        their commands can be changed, however the number of lines must remain
+        identical.
+        If present, then index lines must be at the bottom of the list, i.e. they
+        can not be followed by non-index lines. Also, their commit messages are
+        lost.
 
-        If a line is removed, it will be treated like an 'index' line.
-
-        However, if you remove everything, these changes will be aborted.
+        If you remove everything, the revising process will be aborted.
         """,
     )
 


### PR DESCRIPTION
Deleted lines are no longer treated as index commands. Mention that
the number of lines must remain identical and that index commands must
come last. Adapt 'fixup' and 'squash' to mirror 'git rebase', so that
the 'fixup' help in the todo list mentions that the message is dropped.
Misc rephrasing.

