### PR TITLE
Respect `SEQUENCE_EDITOR` and `sequence.editor` vars

### DIFF
--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from .odb import Commit, Repository
-from .utils import run_editor, edit_commit_message, cut_commit
+from .utils import run_editor, run_sequence_editor, edit_commit_message, cut_commit
 
 
 class StepKind(Enum):
@@ -195,7 +195,7 @@ def edit_todos(repo: Repository, todos: List[Step], msgedit=False) -> List[Step]
     for step in todos:
         todos_text += f"{step} {step.commit.summary()}\n".encode()
 
-    response = run_editor(
+    response = run_sequence_editor(
         repo,
         "git-revise-todo",
         todos_text,


### PR DESCRIPTION
When editing the `revise-todo`, `git-revise` now determines the editor to use with the same logic as `git-rebase-interactive` (see [`git/editor.c`](https://github.com/git/git/blob/b34789c0b0d3b137f0bb516b417bd8d75e0cb306/editor.c#L17-L48)'s `git_editor` v. `git_sequence_editor`).

This is useful if you have a custom sequence editor configured which is different than the normal commit message editor.