### PR TITLE
Support fixups with explicit hashes

### DIFF
--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -121,7 +121,9 @@ def autosquash_todos(todos: List[Step]) -> List[Step]:
         found = None
         needle = summary.split(maxsplit=1)[1]
         for idx, target in enumerate(new_todos):
-            if target.commit.summary().startswith(needle):
+            if target.commit.summary().startswith(
+                needle
+            ) or target.commit.oid.hex().startswith(needle):
                 found = idx
                 break
 

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -234,3 +234,47 @@ def test_fixup_of_fixup(repo):
     assert file1 == b"hello, world\n"
     file2 = new.tree().entries[b"file2"].blob().body
     assert file2 == b"second file\nextra line\neven more\n"
+
+
+def test_fixup_by_id(repo):
+    bash(
+        """
+        echo "hello, world" > file1
+        git add file1
+        git commit -m "commit one"
+
+        echo "second file" > file2
+        git add file2
+        git commit -m "commit two"
+
+        echo "new line!" >> file1
+        git add file1
+        git commit -m "commit three"
+
+        echo "extra line" >> file2
+        git add file2
+        git commit -m "fixup! $(git rev-parse HEAD~)"
+        """
+    )
+
+    old = repo.get_commit("HEAD~~")
+    assert old.persisted
+
+    main(["--autosquash", str(old.parent().oid)])
+
+    new = repo.get_commit("HEAD~")
+    assert old != new, "commit was modified"
+    assert old.parents() == new.parents(), "parents are unchanged"
+
+    assert old.tree() != new.tree(), "tree is changed"
+
+    assert new.message == old.message, "message should not be changed"
+
+    assert new.persisted, "commit persisted to disk"
+    assert new.author == old.author, "author is unchanged"
+    assert new.committer == repo.default_committer, "committer is updated"
+
+    file1 = new.tree().entries[b"file1"].blob().body
+    assert file1 == b"hello, world\n"
+    file2 = new.tree().entries[b"file2"].blob().body
+    assert file2 == b"second file\nextra line\n"


### PR DESCRIPTION
Fixup commits usually use subject line of the target commit. But it is
also possible to specify the target commit's hash directly (or some
prefix of it):

  fixup! faab8b162

This was added in Git in
https://github.com/git/git/commit/68d5d03bc49a073be3b0e14b22d30d70e7ae686d
and currently supported here:
https://github.com/git/git/blob/c44a4c650c66eb7b8d50c57fd4e1bff1add7bf77/sequencer.c#L2853-L2859