### PR TITLE
Add Fedora install instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ managers (Thanks!)
 $ brew install git-revise
 ```
 
+#### Fedora
+
+```sh
+$ dnf install git-revise
+```
+
 ## Documentation
 
 Documentation, including usage and examples, is hosted on [Read the Docs].


### PR DESCRIPTION
Update the readme to show that there is now a Fedora git-revise package that can be installed.