### PR TITLE
Fix order of fixup commits with autosquash

### DIFF
--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -204,7 +204,7 @@ def merge_blobs(
         print(f"Conflict applying '{labels[2]}'")
         print(f"  Path: '{path}'")
         if input("  Edit conflicted file? (Y/n) ").lower() == "n":
-            raise MergeConflict("user aborted")
+            raise MergeConflict("user aborted")  # pylint: disable=W0707
 
         # Open the editor on the conflicted file. We ensure the relative path
         # matches the path of the original file for a better editor experience.
@@ -222,6 +222,6 @@ def merge_blobs(
 
         # Was the merge successful?
         if input("  Merge successful? (y/N) ").lower() != "y":
-            raise MergeConflict("user aborted")
+            raise MergeConflict("user aborted")  # pylint: disable=W0707
 
     return Blob(current.repo, merged)

--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -1,8 +1,8 @@
 import re
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional, Set
 
-from .odb import Commit, Repository
+from .odb import Commit, Oid, Repository
 from .utils import run_editor, run_sequence_editor, edit_commit_message, cut_commit
 
 
@@ -104,8 +104,24 @@ def validate_todos(old: List[Step], new: List[Step]):
             raise ValueError("'index' actions follow all non-index todo items")
 
 
+class CyclicFixupError(Exception):
+    pass
+
+
+def count_fixup_commits(
+    fixups: Dict[Oid, List[Oid]], visited: Set[Oid], node: Oid
+) -> int:
+    if node in visited:
+        raise CyclicFixupError(f"fixups would create cycle in {node}")
+    visited.add(node)
+    return 1 + sum(
+        count_fixup_commits(fixups, visited, fixup) for fixup in fixups.get(node, [])
+    )
+
+
 def autosquash_todos(todos: List[Step]) -> List[Step]:
     new_todos = todos[:]
+    fixups: Dict[Oid, List[Oid]] = {}
 
     for step in todos:
         # Check if this is a fixup! or squash! commit, and ignore it otherwise.
@@ -125,11 +141,19 @@ def autosquash_todos(todos: List[Step]) -> List[Step]:
                 needle
             ) or target.commit.oid.hex().startswith(needle):
                 found = idx
+                if target.commit.oid not in fixups:
+                    fixups[target.commit.oid] = []
+                fixups[target.commit.oid] += [step.commit.oid]
+                number_of_transitive_fixup_commits = (
+                    count_fixup_commits(fixups, set(), target.commit.oid) - 1
+                )
                 break
 
         if found is not None:
             # Insert a new `fixup` or `squash` step in the correct place.
-            new_todos.insert(found + 1, Step(kind, step.commit))
+            new_todos.insert(
+                found + number_of_transitive_fixup_commits, Step(kind, step.commit)
+            )
             # Remove the existing step.
             new_todos.remove(step)
 

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -12,7 +12,13 @@ from .utils import (
     cut_commit,
     local_commits,
 )
-from .todo import apply_todos, build_todos, edit_todos, autosquash_todos
+from .todo import (
+    CyclicFixupError,
+    apply_todos,
+    build_todos,
+    edit_todos,
+    autosquash_todos,
+)
 from .merge import MergeConflict
 from . import __version__
 
@@ -218,6 +224,9 @@ def main(argv: Optional[List[str]] = None):
             inner_main(args, repo)
     except CalledProcessError as err:
         print(f"subprocess exited with non-zero status: {err.returncode}")
+        sys.exit(1)
+    except CyclicFixupError as err:
+        print(f"todo error: {err}")
         sys.exit(1)
     except EditorError as err:
         print(f"editor error: {err}")

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -70,7 +70,7 @@ def edit_file_with_editor(editor: str, path: Path) -> bytes:
             cmd = ["sh", "-c", f'{editor} "$@"', editor, path.name]
         run(cmd, check=True, cwd=path.parent)
     except CalledProcessError as err:
-        raise EditorError(f"Editor exited with status {err}")
+        raise EditorError(f"Editor exited with status {err}") from err
     return path.read_bytes()
 
 
@@ -85,8 +85,10 @@ def get_commentchar(repo: Repository, text: bytes) -> bytes:
                 pass
         try:
             return chars[:1]
-        except IndexError:
-            raise EditorError("Unable to automatically select a comment character")
+        except IndexError as err:
+            raise EditorError(
+                "Unable to automatically select a comment character"
+            ) from err
     if commentchar == b"":
         raise EditorError("core.commentChar must not be empty")
     return commentchar

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -1,6 +1,8 @@
 # pylint: skip-file
 
 from conftest import *
+from gitrevise.utils import commit_range
+from gitrevise.todo import CyclicFixupError, build_todos, autosquash_todos
 import os
 
 
@@ -276,3 +278,74 @@ def test_fixup_by_id(repo):
     assert file1 == b"hello, world\n"
     file2 = new.tree().entries[b"file2"].blob().body
     assert file2 == b"second file\nextra line\n"
+
+
+def test_fixup_order(repo):
+    bash(
+        """
+        git commit --allow-empty -m 'old'
+        git commit --allow-empty -m 'target commit'
+        git commit --allow-empty -m 'first fixup'  --fixup=HEAD
+        git commit --allow-empty -m 'second fixup' --fixup=HEAD~
+        """
+    )
+
+    old = repo.get_commit("HEAD~3")
+    assert old.persisted
+    tip = repo.get_commit("HEAD")
+    assert tip.persisted
+
+    todos = build_todos(commit_range(old, tip), index=None)
+    [target, first, second] = autosquash_todos(todos)
+
+    assert b"target commit" in target.commit.message
+    assert b"first fixup" in first.commit.message
+    assert b"second fixup" in second.commit.message
+
+
+def test_fixup_order_transitive(repo):
+    bash(
+        """
+        git commit --allow-empty -m 'old'
+        git commit --allow-empty -m 'target commit'
+        git commit --allow-empty -m '1.0' --fixup=HEAD
+        git commit --allow-empty -m '1.1' --fixup=HEAD
+        git commit --allow-empty -m '2.0' --fixup=HEAD~2
+        """
+    )
+
+    old = repo.get_commit("HEAD~4")
+    assert old.persisted
+    tip = repo.get_commit("HEAD")
+    assert tip.persisted
+
+    todos = build_todos(commit_range(old, tip), index=None)
+    [target, a, b, c] = autosquash_todos(todos)
+
+    assert b"target commit" in target.commit.message
+    assert b"1.0" in a.commit.message
+    assert b"1.1" in b.commit.message
+    assert b"2.0" in c.commit.message
+
+
+def test_fixup_order_cycle(repo):
+    bash(
+        """
+        git commit --allow-empty -m 'old'
+        git commit --allow-empty -m 'target commit'
+        git commit --allow-empty -m 'fixup! fixup!'
+        """
+    )
+
+    old = repo.get_commit("HEAD~2")
+    assert old.persisted
+    tip = repo.get_commit("HEAD")
+    assert tip.persisted
+
+    todos = build_todos(commit_range(old, tip), index=None)
+
+    try:
+        autosquash_todos(todos)
+        assert False, "Should raise an error on cyclic fixup graphs"
+    except CyclicFixupError:
+        pass

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -103,8 +103,6 @@ def test_fixup_nonhead_editor(basic_repo):
 
 
 def test_fixup_nonhead_conflict(basic_repo):
-    import textwrap
-
     bash('echo "conflict" > file1')
     bash("git add file1")
 


### PR DESCRIPTION
When adding a new fixup to commit X, we want to add it after all previous
fixup commits that target X, and after fixups to those commits, and so on.

The cycle detection might be a bit over-the-top, since the logic only allows
to create self cycles with a message like `fixup! fixup!`.
If we only allowed to fixup previous commits in the todo list, then there would
not be cycles by design, that could simplify this patch.

Fixes #69