### PR TITLE
Add support for GPG-signed commits (#46)

### DIFF
--- a/docs/man.rst
+++ b/docs/man.rst
@@ -58,6 +58,11 @@ General options
 
    Working branch to update; defaults to ``HEAD``.
 
+.. option:: -S, --gpg-sign, --no-gpg-sign
+
+   GPG-sign commits.  To override the ``commit.gpgSign`` git configuration, use
+   ``--no-gpg-sign``
+
 Main modes of operation
 -----------------------
 
@@ -125,6 +130,13 @@ Configuration is managed by :manpage:`git-config(1)`.
    If set to true, imply :option:`--autosquash` whenever :option:`--interactive`
    is specified. Overridden by :option:`--no-autosquash`. Defaults to false. If
    not set, the value of ``rebase.autoSquash`` is used instead.
+
+.. gitconfig:: revise.gpgSign
+
+   If set to true, GPG-sign new commits; defaults to false.  This setting
+   overrides the original git configuration ``Bcommit.gpgSign`` and may be
+   overridden by the command line options ``--gpg-sign`` and
+   ``--no-gpg-sign``.
 
 
 CONFLICT RESOLUTION

--- a/git-revise.1
+++ b/git-revise.1
@@ -79,6 +79,12 @@ Reset target commit\(aqs author to the current user.
 .B \-\-ref <gitref>
 Working branch to update; defaults to \fBHEAD\fP\&.
 .UNINDENT
+.INDENT 0.0
+.TP
+\fB\-\-gpg-sign\fR, \fB\-S\fR, \fB\-\-no\-gpg\-sign
+GPG-sign commits.  To override the \fIcommit.gpgSign\fR git configuration, use
+\fI\-\-no\-gpg\-sign\fR.
+.UNINDENT
 .SS Main modes of operation
 .INDENT 0.0
 .TP
@@ -146,6 +152,14 @@ Configuration is managed by \fBgit\-config(1)\fP\&.
 If set to true, imply \fI\%\-\-autosquash\fP whenever \fI\%\-\-interactive\fP
 is specified. Overridden by \fI\%\-\-no\-autosquash\fP\&. Defaults to false. If
 not set, the value of \fBrebase.autoSquash\fP is used instead.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B revise.gpgSign
+If set to true, GPG-sign new commits; defaults to false.  This setting
+overrides the original git configuration \fBcommit.gpgSign\fR and may be
+overridden by the command line options \fI\-\-gpg\-sign\fR and
+\fI\-\-no\-gpg\-sign\fR.
 .UNINDENT
 .SH CONFLICT RESOLUTION
 .sp

--- a/git-revise.1
+++ b/git-revise.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "GIT-REVISE" "1" "Jun 07, 2020" "0.6.0" "git-revise"
+.TH "GIT-REVISE" "1" "Oct 05, 2020" "0.6.0" "git-revise"
 .SH NAME
 git-revise \- Efficiently update, split, and rearrange git commits
 .
@@ -81,9 +81,9 @@ Working branch to update; defaults to \fBHEAD\fP\&.
 .UNINDENT
 .INDENT 0.0
 .TP
-\fB\-\-gpg-sign\fR, \fB\-S\fR, \fB\-\-no\-gpg\-sign
-GPG-sign commits.  To override the \fIcommit.gpgSign\fR git configuration, use
-\fI\-\-no\-gpg\-sign\fR.
+.B \-S, \-\-gpg\-sign, \-\-no\-gpg\-sign
+GPG\-sign commits.  To override the \fBcommit.gpgSign\fP git configuration, use
+\fB\-\-no\-gpg\-sign\fP
 .UNINDENT
 .SS Main modes of operation
 .INDENT 0.0
@@ -156,10 +156,10 @@ not set, the value of \fBrebase.autoSquash\fP is used instead.
 .INDENT 0.0
 .TP
 .B revise.gpgSign
-If set to true, GPG-sign new commits; defaults to false.  This setting
-overrides the original git configuration \fBcommit.gpgSign\fR and may be
-overridden by the command line options \fI\-\-gpg\-sign\fR and
-\fI\-\-no\-gpg\-sign\fR.
+If set to true, GPG\-sign new commits; defaults to false.  This setting
+overrides the original git configuration \fBBcommit.gpgSign\fP and may be
+overridden by the command line options \fB\-\-gpg\-sign\fP and
+\fB\-\-no\-gpg\-sign\fP\&.
 .UNINDENT
 .SH CONFLICT RESOLUTION
 .sp

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -305,7 +305,7 @@ class Repository:
         if self.sign_commits:
             try:
                 gpg = run(
-                    [self.gpg, "-bsau", self.key_id],
+                    [self.gpg, "--status-fd=2", "-bsau", self.key_id],
                     stdout=PIPE,
                     stderr=PIPE,
                     input=body + body_tail,

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -311,8 +311,11 @@ class Repository:
                     input=body + body_tail,
                     check=True,
                 )
-                body += b"gpgsig " + gpg.stdout.replace(b"\n", b"\n ")
-                body = body[:-1]
+
+                body += b"gpgsig"
+                for line in gpg.stdout.splitlines():
+                    body += b" " + line + b"\n"
+
 
             except CalledProcessError as gpg:
                 print(gpg.stderr.decode(), file=sys.stderr, end="")

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -316,6 +316,8 @@ class Repository:
                 for line in gpg.stdout.splitlines():
                     body += b" " + line + b"\n"
 
+                if not b"\n[GNUPG:] SIG_CREATED " in gpg.stdout:
+                    raise CalledProcessError()
 
             except CalledProcessError as gpg:
                 print(gpg.stderr.decode(), file=sys.stderr, end="")

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -295,3 +295,11 @@ def cut_commit(commit: Commit) -> Commit:
     part2 = edit_commit_message(part2)
 
     return part2
+
+
+def sign_commit(commit: Commit) -> Commit:
+    """Sign the given commit with GPG and return the modified commit."""
+
+    return commit.repo.new_commit(
+        commit.tree(), commit.parents(), message=commit.message
+    )


### PR DESCRIPTION
GPG-sign commits if option -S/--gpg-sign is given, or if configurations
revise.gpgSign or commit.gpgSign are set to true.

The keyid used for signing can be specified by an optional argument to
`-S` or `--gpg-sign` as for git-commit; if not specified explicitly,
default key id is taken from git configuration (user.signingKey) or the
committer signature as fallback.

A call of `git-revise COMMIT --gpg-sign` w/o any changes in the index
causes creation of GPG commit signatures for all commits since COMMIT.

Heavily-contributed-by: krobelus
Signed-off-by: Nicolas Schier <nicolas@fjasle.eu>