### PR TITLE
Support git-rerere to record and replay conflict resolution

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -51,7 +51,7 @@ To avoid spawning unnecessary subprocesses and hitting disk too frequently,
 :command:`git revise` uses an in-memory cache of objects in the ODB which it
 has already seen.
 
-Intermediate git trees, blobs, and commits created during processing are helds
+Intermediate git trees, blobs, and commits created during processing are held
 exclusively in-memory, and only persisted when necessary.
 
 

--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -191,7 +191,7 @@ def merge_blobs(
             str(tmpdir / "current"),
             str(tmpdir / "base"),
             str(tmpdir / "other"),
-            newline=False,
+            trim_newline=False,
         )
     except CalledProcessError as err:
         # The return code is the # of conflicts if there are conflicts, and

--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -10,11 +10,14 @@ files and generate. This algorithm, on the other hand, avoids looking at
 unmodified trees and blobs when possible.
 """
 
-from typing import Optional, Tuple, TypeVar
+from typing import Iterator, Optional, Tuple, TypeVar
 from pathlib import Path
 from subprocess import CalledProcessError
+import hashlib
+import os
+import sys
 
-from .odb import Tree, Blob, Commit, Entry, Mode
+from .odb import Tree, Blob, Commit, Entry, Mode, Repository
 from .utils import edit_file
 
 
@@ -193,6 +196,14 @@ def merge_blobs(
     # Prompt to try and trigger manual resolution.
     print(f"Conflict applying '{labels[2]}'")
     print(f"  Path: '{path}'")
+
+    preimage = merged
+    (normalized_preimage, conflict_id, merged_blob) = replay_recorded_resolution(
+        repo, tmpdir, preimage
+    )
+    if merged_blob is not None:
+        return merged_blob
+
     if input("  Edit conflicted file? (Y/n) ").lower() == "n":
         raise MergeConflict("user aborted")  # pylint: disable=W0707
 
@@ -201,7 +212,6 @@ def merge_blobs(
     conflicts = tmpdir / "conflict" / path.relative_to("/")
     conflicts.parent.mkdir(parents=True, exist_ok=True)
     conflicts.write_bytes(preimage)
-    preimage = merged
     merged = edit_file(repo, conflicts)
 
     # Print warnings if the merge looks like it may have failed.
@@ -214,6 +224,8 @@ def merge_blobs(
     # Was the merge successful?
     if input("  Merge successful? (y/N) ").lower() != "y":
         raise MergeConflict("user aborted")  # pylint: disable=W0707
+
+    record_resolution(repo, conflict_id, normalized_preimage, merged)
 
     return Blob(current.repo, merged)
 
@@ -254,3 +266,145 @@ def merge_files(
             raise
 
         return (False, err.output)  # Conflicted merge
+
+
+def replay_recorded_resolution(
+    repo, tmpdir: Path, preimage
+) -> Tuple[bytes, Optional[str], Optional[Blob]]:
+    rr_cache = repo.git_path("rr-cache")
+    if not repo.bool_config(
+        "revise.rerere",
+        default=repo.bool_config("rerere.enabled", default=rr_cache.is_dir()),
+    ):
+        return (b"", None, None)
+
+    (normalized_preimage, conflict_id) = normalize_conflicted_file(preimage)
+    conflict_dir = rr_cache / conflict_id
+    if not conflict_dir.is_dir():
+        return (normalized_preimage, conflict_id, None)
+    if not repo.bool_config("rerere.autoUpdate", default=False):
+        # TODO: if this option is disabled, Git applies recorded resolutions to
+        # files but doesn't stage them. We should ask the user whether to apply
+        # them. Don't record resolutions for now by returning no conflict ID.
+        return (b"", None, None)
+
+    postimage_path = conflict_dir / "postimage"
+    preimage_path = conflict_dir / "preimage"
+    try:
+        recorded_postimage = postimage_path.read_bytes()
+        recorded_preimage = preimage_path.read_bytes()
+    except IOError as err:
+        print(f"(warning) failed to read git-rerere cache: {err}", file=sys.stderr)
+        return (normalized_preimage, conflict_id, None)
+
+    (is_clean_merge, merged) = merge_files(
+        labels=(
+            "recorded postimage",
+            "recorded preimage",
+            "new preimage",
+        ),
+        current=Blob(repo, recorded_postimage),
+        base=Blob(repo, recorded_preimage),
+        other=Blob(repo, normalized_preimage),
+        tmpdir=tmpdir,
+    )
+    if not is_clean_merge:
+        # We could ask the user to merge this. However, that could be confusing.
+        # Just fall back to letting them resolve the entire conflict.
+        return (normalized_preimage, conflict_id, None)
+
+    print("Successfully replayed recorded resolution")
+    # Mark that "postimage" was used to help git gc. See merge() in Git's rerere.c.
+    os.utime(postimage_path)
+    return (normalized_preimage, conflict_id, Blob(repo, merged))
+
+
+def record_resolution(
+    repo: Repository,
+    conflict_id: Optional[str],
+    normalized_preimage: bytes,
+    postimage: bytes,
+) -> None:
+    if conflict_id is None:
+        return
+
+    # TODO Lock {repo.gitdir}/MERGE_RR until everything is written.
+    print("Recording conflict resolution")
+    conflict_dir = repo.git_path("rr-cache") / conflict_id
+    try:
+        conflict_dir.mkdir(exist_ok=True, parents=True)
+        (conflict_dir / "preimage").write_bytes(normalized_preimage)
+        (conflict_dir / "postimage").write_bytes(postimage)
+    except IOError as err:
+        print(f"(warning) failed to write git-rerere cache: {err}", file=sys.stderr)
+
+
+class ConflictParseFailed(Exception):
+    pass
+
+
+def normalize_conflict(
+    lines: Iterator[bytes],
+    hasher: Optional["hashlib._Hash"],
+) -> bytes:
+    cur_hunk: Optional[bytes] = b""
+    other_hunk: Optional[bytes] = None
+    while True:
+        line = next(lines, None)
+        if line is None:
+            raise ConflictParseFailed("unexpected eof")
+        if line.startswith(b"<<<<<<<"):
+            # parse recursive conflicts, including their processed output in the current hunk
+            conflict = normalize_conflict(lines, None)
+            if cur_hunk is not None:
+                cur_hunk += conflict
+        elif line.startswith(b"|||||||"):
+            # ignore the diff3 original section. Must be still parsing the first hunk.
+            if other_hunk is not None:
+                raise ConflictParseFailed("unexpected ||||||| conflict marker")
+            (other_hunk, cur_hunk) = (cur_hunk, None)
+        elif line.startswith(b"======="):
+            # switch into the second hunk
+            # could be in either the diff3 original section or the first hunk
+            if cur_hunk is not None:
+                if other_hunk is not None:
+                    raise ConflictParseFailed("unexpected ======= conflict marker")
+                other_hunk = cur_hunk
+            cur_hunk = b""
+        elif line.startswith(b">>>>>>>"):
+            # end of conflict. update hasher, and return a normalized conflict
+            if cur_hunk is None or other_hunk is None:
+                raise ConflictParseFailed("unexpected >>>>>>> conflict marker")
+
+            (hunk1, hunk2) = sorted((cur_hunk, other_hunk))
+            if hasher:
+                hasher.update(hunk1 + b"\0")
+                hasher.update(hunk2 + b"\0")
+            return b"".join(
+                (
+                    b"<<<<<<<\n",
+                    hunk1,
+                    b"=======\n",
+                    hunk2,
+                    b">>>>>>>\n",
+                )
+            )
+        elif cur_hunk is not None:
+            # add non-marker lines to the current hunk (or discard if in
+            # the diff3 original section)
+            cur_hunk += line
+
+
+def normalize_conflicted_file(body: bytes) -> Tuple[bytes, str]:
+    hasher = hashlib.sha1()
+    normalized = b""
+
+    lines = iter(body.splitlines(keepends=True))
+    while True:
+        line = next(lines, None)
+        if line is None:
+            return (normalized, hasher.hexdigest())
+        if line.startswith(b"<<<<<<<"):
+            normalized += normalize_conflict(lines, hasher)
+        else:
+            normalized += line

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -183,7 +183,7 @@ class Repository:
         *cmd: str,
         cwd: Optional[Path] = None,
         stdin: Optional[bytes] = None,
-        newline: bool = True,
+        trim_newline: bool = True,
         env: Dict[str, str] = None,
         nocapture: bool = False,
     ) -> bytes:
@@ -202,7 +202,7 @@ class Repository:
 
         if nocapture:
             return b""
-        if newline and prog.stdout.endswith(b"\n"):
+        if trim_newline and prog.stdout.endswith(b"\n"):
             return prog.stdout[:-1]
         return prog.stdout
 
@@ -715,7 +715,7 @@ class Index:
         *cmd: str,
         cwd: Optional[Path] = None,
         stdin: Optional[bytes] = None,
-        newline: bool = True,
+        trim_newline: bool = True,
         env: Optional[Mapping[str, str]] = None,
         nocapture: bool = False,
     ) -> bytes:
@@ -723,7 +723,12 @@ class Index:
         env = dict(**env) if env is not None else dict(**os.environ)
         env["GIT_INDEX_FILE"] = str(self.index_file)
         return self.repo.git(
-            *cmd, cwd=cwd, stdin=stdin, newline=newline, env=env, nocapture=nocapture
+            *cmd,
+            cwd=cwd,
+            stdin=stdin,
+            trim_newline=trim_newline,
+            env=env,
+            nocapture=nocapture,
         )
 
     def tree(self) -> Tree:

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -1,0 +1,327 @@
+# pylint: skip-file
+
+import textwrap
+
+from conftest import *
+from gitrevise.merge import normalize_conflicted_file
+
+
+def history_with_two_conflicting_commits():
+    bash(
+        """
+        git config rerere.enabled true
+        git config rerere.autoUpdate true
+        echo > file; git add file; git commit -m 'initial commit'
+        echo one > file; git commit -am 'commit one'
+        echo two > file; git commit -am 'commit two'
+        """
+    )
+
+
+def test_reuse_recorded_resolution(repo):
+    history_with_two_conflicting_commits()
+
+    with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
+        flip_last_two_commits(repo, ed)
+        with ed.next_file() as f:
+            f.replace_dedent("resolved two\n")
+        with ed.next_file() as f:
+            f.replace_dedent("resolved one\n")
+
+    tree_after_resolving_conflicts = repo.get_commit("HEAD").tree()
+    bash("git reset --hard HEAD@{1}")
+
+    # Now we can change the order of the two commits and reuse the recorded conflict resolution.
+    with editor_main(("-i", "HEAD~~")) as ed:
+        flip_last_two_commits(repo, ed)
+
+    assert tree_after_resolving_conflicts == repo.get_commit("HEAD").tree()
+    leftover_index = hunks(repo.git("diff", "-U0", "HEAD"))
+    assert leftover_index == dedent(
+        """\
+        @@ -1 +1 @@
+        -resolved one
+        +two"""
+    )
+
+    # When we fail to read conflict data from the cache, we fall back to
+    # letting the user resolve the conflict.
+    bash("git reset --hard HEAD@{1}")
+    bash("rm .git/rr-cache/*/preimage")
+    with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
+        flip_last_two_commits(repo, ed)
+        with ed.next_file() as f:
+            f.replace_dedent("resolved two\n")
+        with ed.next_file() as f:
+            f.replace_dedent("resolved one\n")
+
+
+def test_rerere_merge(repo):
+    (repo.workdir / "file").write_bytes(10 * b"x\n")
+    bash(
+        """
+        git config rerere.enabled true
+        git config rerere.autoUpdate true
+        git add file; git commit -m 'initial commit'
+        sed 1coriginal1 -i file; git commit -am 'commit 1'
+        sed 1coriginal2 -i file; git commit -am 'commit 2'
+        """
+    )
+
+    # Record a resolution for changing the order of two commits.
+    with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
+        flip_last_two_commits(repo, ed)
+        with ed.next_file() as f:
+            f.replace_dedent(b"resolved1\n" + 9 * b"x\n")
+        with ed.next_file() as f:
+            f.replace_dedent(b"resolved2\n" + 9 * b"x\n")
+    # Go back to the old history so we can try replaying the resolution.
+    bash("git reset --hard HEAD@{1}")
+
+    # Introduce an unrelated change that will not conflict to check that we can
+    # merge the file contents, and not just use the recorded postimage as is.
+    bash("sed '10c unrelated change, present in all commits' -i file; git add file")
+    main(["HEAD~2"])
+
+    with editor_main(("-i", "HEAD~~")) as ed:
+        flip_last_two_commits(repo, ed)
+
+    assert hunks(repo.git("show", "-U0", "HEAD~")) == dedent(
+        """\
+            @@ -1 +1 @@
+            -x
+            +resolved1"""
+    )
+    assert hunks(repo.git("show", "-U0", "HEAD")) == dedent(
+        """\
+            @@ -1 +1 @@
+            -resolved1
+            +resolved2"""
+    )
+    leftover_index = hunks(repo.git("diff", "-U0", "HEAD"))
+    assert leftover_index == dedent(
+        """\
+        @@ -1 +1 @@
+        -resolved2
+        +original2"""
+    )
+
+
+def test_replay_resolution_recorded_by_git(repo):
+    history_with_two_conflicting_commits()
+    # Switch the order of the last two commits, recording the conflict
+    # resolution with Git itself.
+    bash(
+        r"""
+        one=$(git rev-parse HEAD~)
+        two=$(git rev-parse HEAD)
+        git reset --hard HEAD~~
+        git cherry-pick "$two" 2>&1 | grep 'could not apply'
+        echo resolved two > file; git add file; GIT_EDITOR=: git cherry-pick --continue
+        git cherry-pick "$one" 2>&1 | grep 'could not apply'
+        echo resolved one > file; git add file; GIT_EDITOR=: git cherry-pick --continue --no-edit
+        git reset --hard "$two"
+        """
+    )
+
+    # Now let's try to do the same thing with git-revise, reusing the recorded resolution.
+    with editor_main(("-i", "HEAD~~")) as ed:
+        flip_last_two_commits(repo, ed)
+
+    assert repo.git("log", "-p", trim_newline=False) == dedent(
+        """\
+        commit dc50430ecbd2d0697ee9266ba6057e0e0b511d7f
+        Author: Bash Author <bash_author@example.com>
+        Date:   Thu Jul 13 21:40:00 2017 -0500
+
+            commit one
+
+        diff --git a/file b/file
+        index 474b904..936bcfd 100644
+        --- a/file
+        +++ b/file
+        @@ -1 +1 @@
+        -resolved two
+        +resolved one
+
+        commit e51ab202e87f0557df78e5273dcedf51f408a468
+        Author: Bash Author <bash_author@example.com>
+        Date:   Thu Jul 13 21:40:00 2017 -0500
+
+            commit two
+
+        diff --git a/file b/file
+        index 8b13789..474b904 100644
+        --- a/file
+        +++ b/file
+        @@ -1 +1 @@
+        -
+        +resolved two
+
+        commit d72132e74176624d6c3e5b6b4f5ef774ff23a1b3
+        Author: Bash Author <bash_author@example.com>
+        Date:   Thu Jul 13 21:40:00 2017 -0500
+
+            initial commit
+
+        diff --git a/file b/file
+        new file mode 100644
+        index 0000000..8b13789
+        --- /dev/null
+        +++ b/file
+        @@ -0,0 +1 @@
+        +
+        """
+    )
+
+
+def test_normalize_conflicted_file():
+    # Normalize conflict markers and labels.
+    assert normalize_conflicted_file(
+        dedent(
+            """\
+            <<<<<<< HEAD
+            a
+            =======
+            b
+            >>>>>>> original thingamabob
+
+            unrelated line
+
+            <<<<<<<<<< HEAD
+            c
+            ==========
+            d
+            >>>>>>>>>> longer conflict marker, to be trimmed
+            """
+        )
+    ) == (
+        dedent(
+            """\
+            <<<<<<<
+            a
+            =======
+            b
+            >>>>>>>
+
+            unrelated line
+
+            <<<<<<<
+            c
+            =======
+            d
+            >>>>>>>
+            """
+        ),
+        "3d7cdc2948951408412cc64f3816558407f77e18",
+    )
+
+    # Discard original-text-marker from merge.conflictStyle diff3.
+    assert (
+        normalize_conflicted_file(
+            dedent(
+                """\
+            <<<<<<< theirs
+            a
+            ||||||| common origin
+            b
+            =======
+            c
+            >>>>>>> ours
+            """
+            )
+        )[0]
+        == dedent(
+            """\
+            <<<<<<<
+            a
+            =======
+            c
+            >>>>>>>
+            """
+        )
+    )
+
+    # The two sides of the conflict are ordered.
+    assert (
+        normalize_conflicted_file(
+            dedent(
+                """\
+                <<<<<<< this way round
+                b
+                =======
+                a
+                >>>>>>> (unsorted)
+                """
+            )
+        )[0]
+        == dedent(
+            """\
+            <<<<<<<
+            a
+            =======
+            b
+            >>>>>>>
+            """
+        )
+    )
+
+    # Nested conflict markers.
+    assert (
+        normalize_conflicted_file(
+            dedent(
+                """\
+            <<<<<<<
+            outer left
+            <<<<<<<<<<<
+            inner left
+            |||||||||||
+            inner diff3 original section
+            ===========
+            inner right
+            >>>>>>>>>>>
+            =======
+            outer right
+            >>>>>>>
+            """
+            )
+        )[0]
+        == dedent(
+            """\
+            <<<<<<<
+            outer left
+            <<<<<<<
+            inner left
+            =======
+            inner right
+            >>>>>>>
+            =======
+            outer right
+            >>>>>>>
+            """
+        )
+    )
+
+
+def flip_last_two_commits(repo: Repository, ed: Editor):
+    head = repo.get_commit("HEAD")
+    with ed.next_file() as f:
+        lines = f.indata.splitlines()
+        assert lines[0].startswith(b"pick " + head.parent().oid.short().encode())
+        assert lines[1].startswith(b"pick " + head.oid.short().encode())
+        assert not lines[2], "expect todo list with exactly two items"
+
+        f.replace_dedent(
+            f"""\
+            pick {head.oid.short()}
+            pick {head.parent().oid.short()}
+            """
+        )
+
+
+def dedent(text: str) -> bytes:
+    return textwrap.dedent(text).encode()
+
+
+def hunks(diff: bytes) -> bytes:
+    return diff[diff.index(b"@@") :]


### PR DESCRIPTION
This adds basic support for [git-rerere].
Whenever a merge conflict in a file is successfully resolved by the user,
the conflict (the preimage) and the merged file (the postimage) are recorded.
When resolving the same conflict again, the recorded resolution is replayed,
unless it doesn't merge cleanly with the current preimage.

The resolutions are shared with the ones that git-rerere records;
both save them in .git/rr-cache/<conflict-id>.

My motivation is that I'm using git-revise in a script that sometimes needs
to resolve the same conflicts over and over again. By caching conflict
resolutions I only need to do that once.

This feature is disabled by default.  Use it by enabling revise.rerere (or
rerere.enabled) _and_ rerere.autoUpdate. In future, we plan to also support
use without rerere.autoUpdate.

Upstream git-rerere can remember multiple resolutions for each conflict,
so-called "variants".  This is not yet supported by this patch - we only
keep the last resolution for each conflict around. This should probably be
added in a future patch.

[git-rerere]: <https://git-scm.com/docs/git-rerere/>