### PR TITLE
Rule out fixup cycles by building autosquash todo list step by step

### DIFF
--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -12,13 +12,7 @@ from .utils import (
     cut_commit,
     local_commits,
 )
-from .todo import (
-    CyclicFixupError,
-    apply_todos,
-    build_todos,
-    edit_todos,
-    autosquash_todos,
-)
+from .todo import apply_todos, build_todos, edit_todos, autosquash_todos
 from .merge import MergeConflict
 from . import __version__
 
@@ -224,9 +218,6 @@ def main(argv: Optional[List[str]] = None):
             inner_main(args, repo)
     except CalledProcessError as err:
         print(f"subprocess exited with non-zero status: {err.returncode}")
-        sys.exit(1)
-    except CyclicFixupError as err:
-        print(f"todo error: {err}")
         sys.exit(1)
     except EditorError as err:
         print(f"editor error: {err}")


### PR DESCRIPTION
This eliminates the need to check for a cycle in the fixup graph, see
5f4639a Fix order of fixup commits with autosquash (#72).

---

I guess `visited` could stay with a hard fail instead of looping when there is a cycle, but that is impossible at the moment.