### PR TITLE
Support multiline commit summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNEXT
+
+* Fix handling of multiline commit subjects (#86)
+
 ## v0.6.0
 
 * Fixed handling of fixup-of-fixup commits (#58)

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -515,8 +515,12 @@ class Commit(GitObj):
         return self.parents()[0]
 
     def summary(self) -> str:
-        """The summary line (first line) of the commit message"""
-        return self.message.split(b"\n", maxsplit=1)[0].decode(errors="replace")
+        """The summary line of the commit message. Returns the summary
+        as a single line, even if it spans multiple lines."""
+        summary_paragraph = self.message.split(b"\n\n", maxsplit=1)[0].decode(
+            errors="replace"
+        )
+        return " ".join(summary_paragraph.splitlines())
 
     def rebase(self, parent: "Commit") -> "Commit":
         """Create a new commit with the same changes, except with ``parent``


### PR DESCRIPTION
A Git commit summary (also called "subject") includes all lines before
the first blank line in the commit message.

When creating a fixup commit for a commit X, Git joins all lines in
the summary of X, so the "fixup! Summary of X" message will always
be a single line.

The same thing happens when building a rebase-todo list. Joining the
subject into one line makes sure that multiline summaries don't create
invalid todo lists.

Always squash the summary into one line, since we use it only in
contexts where a single line is desired.