### PR TITLE
Allow more spaces after the command keyword

### DIFF
--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -48,7 +48,7 @@ class Step:
 
     @staticmethod
     def parse(repo: Repository, instr: str) -> "Step":
-        parsed = re.match(r"(?P<command>\S+)\s(?P<hash>\S+)", instr)
+        parsed = re.match(r"(?P<command>\S+)\s+(?P<hash>\S+)", instr)
         if not parsed:
             raise ValueError(
                 f"todo entry '{instr}' must follow format <keyword> <sha> <optional message>"


### PR DESCRIPTION
This matches the git-rebase behavior

---------------

Inserting an extra space in the todo-list no longer fails with `invalid value: todo entry 'r <EXTRA SPACE> <HASH> ...'`