### PR TITLE
rerere: Skip mismatched marker sizes like git-rerere does

### DIFF
--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -375,7 +375,7 @@ def normalize_conflict(
         line = next(lines, None)
         if line is None:
             raise ConflictParseFailed("unexpected eof")
-        if line.startswith(b"<<<<<<<"):
+        if line.startswith(b"<<<<<<< "):
             # parse recursive conflicts, including their processed output in the current hunk
             conflict = normalize_conflict(lines, None)
             if cur_hunk is not None:
@@ -393,7 +393,7 @@ def normalize_conflict(
                     raise ConflictParseFailed("unexpected ======= conflict marker")
                 other_hunk = cur_hunk
             cur_hunk = b""
-        elif line.startswith(b">>>>>>>"):
+        elif line.startswith(b">>>>>>> "):
             # end of conflict. update hasher, and return a normalized conflict
             if cur_hunk is None or other_hunk is None:
                 raise ConflictParseFailed("unexpected >>>>>>> conflict marker")
@@ -426,7 +426,7 @@ def normalize_conflicted_file(body: bytes) -> Tuple[bytes, str]:
         line = next(lines, None)
         if line is None:
             return (normalized, hasher.hexdigest())
-        if line.startswith(b"<<<<<<<"):
+        if line.startswith(b"<<<<<<< "):
             normalized += normalize_conflict(lines, hasher)
         else:
             normalized += line

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -236,7 +236,7 @@ def test_normalize_conflicted_file() -> None:
             c
             ==========
             d
-            >>>>>>>>>> longer conflict marker, to be trimmed
+            >>>>>>>>>> longer conflict marker, to be ignored
             """
         )
     ) == (
@@ -250,14 +250,14 @@ def test_normalize_conflicted_file() -> None:
 
             unrelated line
 
-            <<<<<<<
+            <<<<<<<<<< HEAD
             c
-            =======
+            ==========
             d
-            >>>>>>>
+            >>>>>>>>>> longer conflict marker, to be ignored
             """
         ),
-        "3d7cdc2948951408412cc64f3816558407f77e18",
+        "0630df854874fc5ffb92a197732cce0d8928e898",
     )
 
     # Discard original-text-marker from merge.conflictStyle diff3.
@@ -315,18 +315,18 @@ def test_normalize_conflicted_file() -> None:
         normalize_conflicted_file(
             dedent(
                 """\
-            <<<<<<<
+            <<<<<<< ours (outer)
             outer left
-            <<<<<<<<<<<
+            <<<<<<< ours (inner)
             inner left
-            |||||||||||
+            |||||||
             inner diff3 original section
-            ===========
+            =======
             inner right
-            >>>>>>>>>>>
+            >>>>>>> theirs (inner)
             =======
             outer right
-            >>>>>>>
+            >>>>>>> theirs (outer)
             """
             )
         )[0]


### PR DESCRIPTION
When parsing conflicts, `git-rerere` ignores/preserves conflict markers that are not exactly the expected length, which defaults to 7.

For `<<<<<<< ` and `>>>>>>> `, it also requires them to end in a space, to avoid ambiguity.

See [`git/rerere.c`:`is_cmarker`](https://github.com/git/git/blob/cefe983a320c03d7843ac78e73bd513a27806845/rerere.c#L319) for reference + additional commentary.

This updates git-revise's parsing to treat them the same way.