### PR TITLE
cut: Enable splitting root commits

### DIFF
--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -506,6 +506,18 @@ class Commit(GitObj):
         """``tree`` object corresponding to this commit"""
         return self.repo.get_tree(self.tree_oid)
 
+    def parent_tree(self) -> "Tree":
+        """``tree`` object corresponding to the first parent of this commit,
+        or the null tree if this is a root commit"""
+        if self.is_root:
+            return Tree(self.repo, b"")
+        return self.parents()[0].tree()
+
+    @property
+    def is_root(self) -> bool:
+        """Whether this commit has no parents"""
+        return not self.parent_oids
+
     def parents(self) -> Sequence["Commit"]:
         """List of parent commits"""
         return [self.repo.get_commit(parent) for parent in self.parent_oids]

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -196,7 +196,7 @@ def inner_main(args: Namespace, repo: Repository) -> None:
     staged = None
     if not args.no_index:
         staged = repo.index.commit(message=b"<git index>")
-        if staged.tree() == staged.parent().tree():
+        if staged.tree() == staged.parent_tree():
             staged = None  # No changes, ignore the commit
 
     # Determine the HEAD reference which we're going to update.

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -224,10 +224,10 @@ def edit_commit_message(commit: Commit) -> Commit:
         "with '#' will be ignored, and an empty message aborts the commit.\n"
     )
 
-    # If the target commit is not the initial commit, produce a diff --stat to
+    # If the target commit is not a merge commit, produce a diff --stat to
     # include in the commit message comments.
-    if len(commit.parents()) == 1:
-        tree_a = commit.parent().tree().persist().hex()
+    if len(commit.parents()) < 2:
+        tree_a = commit.parent_tree().persist().hex()
         tree_b = commit.tree().persist().hex()
         comments += "\n" + repo.git("diff-tree", "--stat", tree_a, tree_b).decode()
 
@@ -261,7 +261,7 @@ def cut_commit(commit: Commit) -> Commit:
     print(f"Cutting commit {commit.oid.short()}")
     print("Select changes to be included in part [1]:")
 
-    base_tree = commit.parent().tree()
+    base_tree = commit.parent_tree()
     final_tree = commit.tree()
 
     # Create an environment with an explicit index file and the base tree.


### PR DESCRIPTION
This allows root commits to be split with `git revise -c`.

This is related to and assists—but does not implement—#81 (_Add `--root` option_). Since `-c <commit>` refers to an actual targeted commit this was a bit easier as a first step. `-i <parent|--root>` refers to the possibly-non-existent parent, which requires a bit more special handling.