### PR TITLE
merge.merge_entries: Prompt for file mode resolution vs assuming `EXEC`

### DIFF
--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -119,7 +119,15 @@ def merge_entries(
         elif base and base.mode == other.mode:
             mode = current.mode
         else:
-            mode = Mode.EXEC  # XXX: gross
+            mode = conflict_prompt(
+                path,
+                "File mode",
+                labels,
+                current.mode,
+                str(current.mode),
+                other.mode,
+                str(other.mode),
+            )
     else:
         return conflict_prompt(
             path,


### PR DESCRIPTION
When two entries are both files but have conflicting permissions (`755` vs `644`), previously `git-revise` would default to `755`. Instead, this now prompts the user to choose which mode they want.