### PR TITLE
odb.git: Send captured-but-discarded output to `DEVNULL`

### DIFF
--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -25,7 +25,7 @@ import sys
 from types import TracebackType
 from pathlib import Path
 from enum import Enum
-from subprocess import Popen, run, PIPE, CalledProcessError
+from subprocess import DEVNULL, Popen, run, PIPE, CalledProcessError
 from collections import defaultdict
 from tempfile import TemporaryDirectory
 
@@ -771,13 +771,24 @@ class Tree(GitObj):
         entry in the index will have its "Skip Workdir" bit set."""
 
         index = Index(self.repo, path)
-        self.repo.git("read-tree", "--index-output=" + str(path), self.persist().hex())
+        self.repo.git(
+            "read-tree",
+            "--index-output=" + str(path),
+            self.persist().hex(),
+            stdout=DEVNULL,
+        )
 
         # If skip_worktree is set, mark every file as --skip-worktree.
         if skip_worktree:
             # XXX(nika): Could be done with a pipe, which might improve perf.
             files = index.git("ls-files")
-            index.git("update-index", "--skip-worktree", "--stdin", stdin=files)
+            index.git(
+                "update-index",
+                "--skip-worktree",
+                "--stdin",
+                stdin=files,
+                stdout=DEVNULL,
+            )
 
         return index
 
@@ -898,5 +909,5 @@ class Reference(Generic[GitObjT]):  # pylint: disable=unsubscriptable-object
         if self.target is not None:
             args.append(str(self.target.oid))
 
-        self.repo.git(*args)
+        self.repo.git(*args, stdout=DEVNULL)
         self.target = new

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -8,11 +8,10 @@ import hashlib
 import re
 import os
 from typing import (
+    TYPE_CHECKING,
     TypeVar,
     Type,
-    Any,
     Dict,
-    IO,
     Union,
     Sequence,
     Optional,
@@ -30,6 +29,10 @@ from collections import defaultdict
 from tempfile import TemporaryDirectory
 
 
+if TYPE_CHECKING:
+    from subprocess import _FILE
+
+
 class MissingObject(Exception):
     """Exception raised when a commit cannot be found in the ODB"""
 
@@ -45,7 +48,6 @@ class GPGSignError(Exception):
 
 
 T = TypeVar("T")  # pylint: disable=invalid-name
-_FILE = Union[None, int, IO[Any]]
 
 
 class Oid(bytes):

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -10,7 +10,9 @@ import os
 from typing import (
     TypeVar,
     Type,
+    Any,
     Dict,
+    IO,
     Union,
     Sequence,
     Optional,
@@ -43,6 +45,7 @@ class GPGSignError(Exception):
 
 
 T = TypeVar("T")  # pylint: disable=invalid-name
+_FILE = Union[None, int, IO[Any]]
 
 
 class Oid(bytes):
@@ -219,7 +222,7 @@ class Repository:
         cwd: Optional[Path] = None,
         env: Dict[str, str] = None,
         stdin: Optional[bytes] = None,
-        nocapture: bool = False,
+        stdout: _FILE = PIPE,
         trim_newline: bool = True,
     ) -> bytes:
         if cwd is None:
@@ -231,14 +234,13 @@ class Repository:
             cwd=cwd,
             env=env,
             input=stdin,
-            stdout=None if nocapture else PIPE,
+            stdout=stdout,
             check=True,
         )
 
-        if nocapture:
-            return b""
-        if trim_newline and prog.stdout.endswith(b"\n"):
-            return prog.stdout[:-1]
+        if trim_newline and isinstance(prog.stdout, bytes):
+            if prog.stdout.endswith(b"\n"):
+                return prog.stdout[:-1]
         return prog.stdout
 
     def config(self, setting: str, default: T) -> Union[bytes, T]:
@@ -816,7 +818,7 @@ class Index:
         cwd: Optional[Path] = None,
         env: Optional[Mapping[str, str]] = None,
         stdin: Optional[bytes] = None,
-        nocapture: bool = False,
+        stdout: _FILE = PIPE,
         trim_newline: bool = True,
     ) -> bytes:
         """Invoke git with the given index as active"""
@@ -827,7 +829,7 @@ class Index:
             cwd=cwd,
             env=env,
             stdin=stdin,
-            nocapture=nocapture,
+            stdout=stdout,
             trim_newline=trim_newline,
         )
 

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -217,10 +217,10 @@ class Repository:
         self,
         *cmd: str,
         cwd: Optional[Path] = None,
-        stdin: Optional[bytes] = None,
-        trim_newline: bool = True,
         env: Dict[str, str] = None,
+        stdin: Optional[bytes] = None,
         nocapture: bool = False,
+        trim_newline: bool = True,
     ) -> bytes:
         if cwd is None:
             cwd = getattr(self, "workdir", None)
@@ -228,10 +228,10 @@ class Repository:
         cmd = ("git",) + cmd
         prog = run(
             cmd,
-            stdout=None if nocapture else PIPE,
             cwd=cwd,
             env=env,
             input=stdin,
+            stdout=None if nocapture else PIPE,
             check=True,
         )
 
@@ -814,10 +814,10 @@ class Index:
         self,
         *cmd: str,
         cwd: Optional[Path] = None,
-        stdin: Optional[bytes] = None,
-        trim_newline: bool = True,
         env: Optional[Mapping[str, str]] = None,
+        stdin: Optional[bytes] = None,
         nocapture: bool = False,
+        trim_newline: bool = True,
     ) -> bytes:
         """Invoke git with the given index as active"""
         env = dict(**env) if env is not None else dict(**os.environ)
@@ -825,10 +825,10 @@ class Index:
         return self.repo.git(
             *cmd,
             cwd=cwd,
-            stdin=stdin,
-            trim_newline=trim_newline,
             env=env,
+            stdin=stdin,
             nocapture=nocapture,
+            trim_newline=trim_newline,
         )
 
     def tree(self) -> Tree:

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, List
 from argparse import ArgumentParser, Namespace
-from subprocess import DEVNULL, CalledProcessError
+from subprocess import CalledProcessError
 import sys
 
 from .odb import Repository, Commit, Reference
@@ -227,10 +227,11 @@ def noninteractive(
 
 def inner_main(args: Namespace, repo: Repository) -> None:
     # If '-a' or '-p' was specified, stage changes.
+    # Note that stdout=None means "inherit current stdout".
     if args.all:
-        repo.git("add", "-u", stdout=DEVNULL)
+        repo.git("add", "-u", stdout=None)
     if args.patch:
-        repo.git("add", "-p", stdout=DEVNULL)
+        repo.git("add", "-p", stdout=None)
 
     if args.gpg_sign:
         repo.sign_commits = True

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, List
 from argparse import ArgumentParser, Namespace
-from subprocess import CalledProcessError
+from subprocess import DEVNULL, CalledProcessError
 import sys
 
 from .odb import Repository, Commit, Reference
@@ -228,9 +228,9 @@ def noninteractive(
 def inner_main(args: Namespace, repo: Repository) -> None:
     # If '-a' or '-p' was specified, stage changes.
     if args.all:
-        repo.git("add", "-u")
+        repo.git("add", "-u", stdout=DEVNULL)
     if args.patch:
-        repo.git("add", "-p")
+        repo.git("add", "-p", stdout=DEVNULL)
 
     if args.gpg_sign:
         repo.sign_commits = True

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -275,7 +275,7 @@ def cut_commit(commit: Commit) -> Commit:
 
     # Run an interactive git-reset to allow picking which pieces of the
     # patch should go into the first part.
-    index.git("reset", "--patch", final_tree.persist().hex(), "--", ".", nocapture=True)
+    index.git("reset", "--patch", final_tree.persist().hex(), "--", ".", stdout=None)
 
     # Write out the newly created tree.
     mid_tree = index.tree()


### PR DESCRIPTION
This avoids buffering captured output that's always discarded. The parameter change from `nocapture` to `stdout` also makes it possible to direct that output to some other file/pipe.