### PR TITLE
test.edit: Bind to randomly-allocated port to avoid conflicts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,6 @@ import dummy_editor
 
 
 EDITOR_SERVER_ADDR = ("127.0.0.1", 8190)
-EDITOR_COMMAND = " ".join(
-    shlex.quote(p)
-    for p in (
-        sys.executable,
-        dummy_editor.__file__,
-        "http://{0}:{1}/".format(*EDITOR_SERVER_ADDR),
-    )
-)
 
 
 @pytest.fixture(autouse=True)
@@ -125,7 +117,16 @@ def main(args, **kwargs):
 @contextmanager
 def editor_main(args, **kwargs):
     with pytest.MonkeyPatch().context() as m, Editor() as ed:
-        m.setenv("GIT_EDITOR", EDITOR_COMMAND)
+        editor_cmd = " ".join(
+            shlex.quote(p)
+            for p in (
+                sys.executable,
+                dummy_editor.__file__,
+                "http://{0}:{1}/".format(*EDITOR_SERVER_ADDR),
+            )
+        )
+        m.setenv("GIT_EDITOR", editor_cmd)
+
         with in_parallel(main, args, **kwargs):
             yield ed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,12 @@ import dummy_editor
 
 EDITOR_SERVER_ADDR = ("127.0.0.1", 8190)
 EDITOR_COMMAND = " ".join(
-    shlex.quote(p) for p in (sys.executable, dummy_editor.__file__)
+    shlex.quote(p)
+    for p in (
+        sys.executable,
+        dummy_editor.__file__,
+        "http://{0}:{1}/".format(*EDITOR_SERVER_ADDR),
+    )
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,6 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 import dummy_editor
 
 
-EDITOR_SERVER_ADDR = ("127.0.0.1", 8190)
-
-
 @pytest.fixture(autouse=True)
 def hermetic_seal(tmp_path_factory, monkeypatch):
     # Lock down user git configuration
@@ -202,7 +199,8 @@ class EditorFile(BaseHTTPRequestHandler):
 
 class Editor(HTTPServer):
     def __init__(self):
-        super().__init__(EDITOR_SERVER_ADDR, EditorFile)
+        # Bind to a randomly-allocated free port.
+        super().__init__(("127.0.0.1", 0), EditorFile)
         self.request_ready = Event()
         self.handle_thread = None
         self.current = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,7 +204,7 @@ class Editor(HTTPServer):
         self.request_ready = Event()
         self.handle_thread = None
         self.current = None
-        self.timeout = 5
+        self.timeout = 10
 
     def next_file(self):
         assert self.handle_thread is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,12 @@
 # pylint: skip-file
 
 import pytest
-import shutil
 import shlex
 import os
 import sys
 import textwrap
 import subprocess
 import traceback
-import time
-from pathlib import Path
 from gitrevise.odb import Repository
 from contextlib import contextmanager
 from threading import Thread, Event

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ def editor_main(args, **kwargs):
             for p in (
                 sys.executable,
                 dummy_editor.__file__,
-                "http://{0}:{1}/".format(*EDITOR_SERVER_ADDR),
+                "http://{0}:{1}/".format(*ed.server_address[:2]),
             )
         )
         m.setenv("GIT_EDITOR", editor_cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,23 +11,13 @@ from gitrevise.odb import Repository
 from contextlib import contextmanager
 from threading import Thread, Event
 from http.server import HTTPServer, BaseHTTPRequestHandler
+import dummy_editor
 
 
 EDITOR_SERVER_ADDR = ("127.0.0.1", 8190)
-EDITOR_SCRIPT = """\
-import sys
-from pathlib import Path
-from urllib.request import urlopen
-
-path = Path(sys.argv[1]).resolve()
-with urlopen('http://127.0.0.1:8190/', data=path.read_bytes(), timeout=5) as r:
-    length = int(r.headers.get('content-length'))
-    data = r.read(length)
-    if r.status != 200:
-        raise Exception(data.decode())
-path.write_bytes(data)
-"""
-EDITOR_COMMAND = " ".join(shlex.quote(p) for p in (sys.executable, "-c", EDITOR_SCRIPT))
+EDITOR_COMMAND = " ".join(
+    shlex.quote(p) for p in (sys.executable, dummy_editor.__file__)
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/dummy_editor.py
+++ b/tests/dummy_editor.py
@@ -3,9 +3,9 @@ from pathlib import Path
 from urllib.request import urlopen
 
 
-def run_editor(path: Path) -> None:
+def run_editor(path: Path, url: str) -> None:
     # pylint: disable=invalid-name
-    with urlopen("http://127.0.0.1:8190/", data=path.read_bytes(), timeout=5) as r:
+    with urlopen(url, data=path.read_bytes(), timeout=5) as r:
         length = int(r.headers.get("content-length"))
         data = r.read(length)
         if r.status != 200:
@@ -14,4 +14,4 @@ def run_editor(path: Path) -> None:
 
 
 if __name__ == "__main__":
-    run_editor(path=Path(sys.argv[1]).resolve())
+    run_editor(url=sys.argv[1], path=Path(sys.argv[2]).resolve())

--- a/tests/dummy_editor.py
+++ b/tests/dummy_editor.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 
-if __name__ == "__main__":
-    path = Path(sys.argv[1]).resolve()
+def run_editor(path: Path) -> None:
     # pylint: disable=invalid-name
     with urlopen("http://127.0.0.1:8190/", data=path.read_bytes(), timeout=5) as r:
         length = int(r.headers.get("content-length"))
@@ -12,3 +11,7 @@ if __name__ == "__main__":
         if r.status != 200:
             raise Exception(data.decode())
     path.write_bytes(data)
+
+
+if __name__ == "__main__":
+    run_editor(path=Path(sys.argv[1]).resolve())

--- a/tests/dummy_editor.py
+++ b/tests/dummy_editor.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+from urllib.request import urlopen
+
+
+if __name__ == "__main__":
+    path = Path(sys.argv[1]).resolve()
+    # pylint: disable=invalid-name
+    with urlopen("http://127.0.0.1:8190/", data=path.read_bytes(), timeout=5) as r:
+        length = int(r.headers.get("content-length"))
+        data = r.read(length)
+        if r.status != 200:
+            raise Exception(data.decode())
+    path.write_bytes(data)

--- a/tests/dummy_editor.py
+++ b/tests/dummy_editor.py
@@ -5,7 +5,7 @@ from urllib.request import urlopen
 
 def run_editor(path: Path, url: str) -> None:
     # pylint: disable=invalid-name
-    with urlopen(url, data=path.read_bytes(), timeout=5) as r:
+    with urlopen(url, data=path.read_bytes(), timeout=10) as r:
         length = int(r.headers.get("content-length"))
         data = r.read(length)
         if r.status != 200:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,6 +1,5 @@
 # pylint: skip-file
 
-import textwrap
 import pytest
 from conftest import *
 


### PR DESCRIPTION
Previously, the test editor would always bind to port `8190`. However, this could cause problems if multiple tests are run in parallel on the same machine, or if that port is already bound by some other application.

This updates that fixture to bind to port `0`, which requests an unused port to be assigned by the OS. Then the `GIT_EDITOR` command uses whatever port was assigned.