### PR TITLE
interactive: Allow targeting `--root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix autosquash order of multiple fixup commits with the same target (#72)
 * Use `GIT_SEQUENCE_EDITOR` instead of `SEQUENCE_EDITOR` (#71)
 * Fix handling of multiline commit subjects (#86)
+* Add support for interactively revising the root commit via `--root`
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fix autosquash order of multiple fixup commits with the same target (#72)
 * Use `GIT_SEQUENCE_EDITOR` instead of `SEQUENCE_EDITOR` (#71)
 * Fix handling of multiline commit subjects (#86)
-* Add support for interactively revising the root commit via `--root`
+* Add support for interactively revising or autosquashing the root commit via `--root`
 
 ## v0.6.0
 

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -170,6 +170,13 @@ This mode is started with the last commit you want to retain "as-is":
 
     git revise -i <after-this-commit>
 
+The special target `--root` is available to revise everything up to the root
+commit:
+
+.. code-block:: bash
+
+    git revise -i --root
+
 An editor will be fired up with the commits in your current branch after the
 given commit. If the index has any staged but uncommitted changes, a ``<git
 index>`` entry will also be present.

--- a/docs/man.rst
+++ b/docs/man.rst
@@ -29,8 +29,10 @@ writing them when necessary. This allows it to be significantly faster on
 large codebases, and avoid invalidating builds.
 
 If :option:`--autosquash` or :option:`--interactive` is specified, the
-<target> argument is optional. If it is omitted, :program:`git revise` will
-consider a range of unpublished commits on the current branch.
+<target> argument may be omitted or given as the special value `:option:--root`.
+If it is omitted, :program:`git revise` will consider a range of unpublished
+commits on the current branch. If given as `:option:--root`, all commits
+including the root commit will be considered.
 
 OPTIONS
 =======

--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -28,21 +28,34 @@ class MergeConflict(Exception):
     pass
 
 
-def rebase(commit: Commit, parent: Commit) -> Commit:
-    if commit.parent() == parent:
+def rebase(commit: Commit, new_parent: Optional[Commit]) -> Commit:
+    repo = commit.repo
+
+    orig_parent = commit.parent() if not commit.is_root else None
+
+    if orig_parent == new_parent:
         return commit  # No need to do anything
+
+    def get_summary(cmt: Optional[Commit]) -> str:
+        return cmt.summary() if cmt is not None else "<root>"
+
+    def get_tree(cmt: Optional[Commit]) -> Tree:
+        return cmt.tree() if cmt is not None else Tree(repo, b"")
 
     tree = merge_trees(
         Path("/"),
-        (parent.summary(), commit.parent().summary(), commit.summary()),
-        parent.tree(),
-        commit.parent().tree(),
-        commit.tree(),
+        (get_summary(new_parent), get_summary(orig_parent), get_summary(commit)),
+        get_tree(new_parent),
+        get_tree(orig_parent),
+        get_tree(commit),
     )
+
+    new_parents = [new_parent] if new_parent is not None else []
+
     # NOTE: This omits commit.committer to pull it from the environment. This
     # means that created commits may vary between invocations, but due to
     # caching, should be consistent within a single process.
-    return tree.repo.new_commit(tree, [parent], commit.message, commit.author)
+    return commit.update(tree=tree, parents=new_parents)
 
 
 def conflict_prompt(

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -538,9 +538,9 @@ class Commit(GitObj):
         )
         return " ".join(summary_paragraph.splitlines())
 
-    def rebase(self, parent: "Commit") -> "Commit":
+    def rebase(self, parent: Optional["Commit"]) -> "Commit":
         """Create a new commit with the same changes, except with ``parent``
-        as it's parent."""
+        as its parent. If ``parent`` is ``None``, this becomes a root commit."""
         from .merge import rebase  # pylint: disable=import-outside-toplevel
 
         return rebase(self, parent)

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -506,6 +506,18 @@ class Commit(GitObj):
         """``tree`` object corresponding to this commit"""
         return self.repo.get_tree(self.tree_oid)
 
+    def parent_tree(self) -> "Tree":
+        """``tree`` object corresponding to the first parent of this commit,
+        or the null tree if this is a root commit"""
+        if self.is_root:
+            return Tree(self.repo, b"")
+        return self.parents()[0].tree()
+
+    @property
+    def is_root(self) -> bool:
+        """Whether this commit has no parents"""
+        return not self.parent_oids
+
     def parents(self) -> Sequence["Commit"]:
         """List of parent commits"""
         return [self.repo.get_commit(parent) for parent in self.parent_oids]

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -149,7 +149,10 @@ def noninteractive(
     assert head.target is not None
 
     if args.root:
-        raise ValueError("Incompatible option: --root requires --interactive")
+        raise ValueError(
+            "Incompatible option: "
+            "--root may only be used with --autosquash or --interactive"
+        )
 
     if args.target is None:
         raise ValueError("<target> is a required argument")

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -196,7 +196,7 @@ def inner_main(args: Namespace, repo: Repository) -> None:
     staged = None
     if not args.no_index:
         staged = repo.index.commit(message=b"<git index>")
-        if staged.tree() == staged.parent().tree():
+        if staged.tree() == staged.parent_tree():
             staged = None  # No changes, ignore the commit
 
     # Determine the HEAD reference which we're going to update.

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -14,12 +14,14 @@ class EditorError(Exception):
     pass
 
 
-def commit_range(base: Commit, tip: Commit) -> List[Commit]:
+def commit_range(base: Optional[Commit], tip: Commit) -> List[Commit]:
     """Oldest-first iterator over the given commit range,
     not including the commit ``base``"""
     commits = []
     while tip != base:
         commits.append(tip)
+        if tip.is_root and base is None:
+            break
         tip = tip.parent()
     commits.reverse()
     return commits

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -224,10 +224,10 @@ def edit_commit_message(commit: Commit) -> Commit:
         "with '#' will be ignored, and an empty message aborts the commit.\n"
     )
 
-    # If the target commit is not the initial commit, produce a diff --stat to
+    # If the target commit is not a merge commit, produce a diff --stat to
     # include in the commit message comments.
-    if len(commit.parents()) == 1:
-        tree_a = commit.parent().tree().persist().hex()
+    if len(commit.parents()) < 2:
+        tree_a = commit.parent_tree().persist().hex()
         tree_b = commit.tree().persist().hex()
         comments += "\n" + repo.git("diff-tree", "--stat", tree_a, tree_b).decode()
 
@@ -261,7 +261,7 @@ def cut_commit(commit: Commit) -> Commit:
     print(f"Cutting commit {commit.oid.short()}")
     print("Select changes to be included in part [1]:")
 
-    base_tree = commit.parent().tree()
+    base_tree = commit.parent_tree()
     final_tree = commit.tree()
 
     # Create an environment with an explicit index file and the base tree.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -68,6 +68,65 @@ def test_interactive_reorder_subdir(repo):
     interactive_reorder_helper(repo, cwd=repo.workdir / "subdir")
 
 
+def test_interactive_on_root(repo):
+    bash(
+        """
+        echo "hello, world" > file1
+        git add file1
+        git commit -m "commit one"
+
+        echo "second file" > file2
+        git add file2
+        git commit -m "commit two"
+
+        echo "new line!" >> file1
+        git add file1
+        git commit -m "commit three"
+        """
+    )
+
+    orig_commit3 = prev = repo.get_commit("HEAD")
+    orig_commit2 = prev_u = prev.parent()
+    orig_commit1 = prev_u.parent()
+
+    index_tree = repo.index.tree()
+
+    with editor_main(["-i", "--root"]) as ed:
+        with ed.next_file() as f:
+            assert f.startswith_dedent(
+                f"""\
+                pick {prev.parent().parent().oid.short()} commit one
+                pick {prev.parent().oid.short()} commit two
+                pick {prev.oid.short()} commit three
+                """
+            )
+            f.replace_dedent(
+                f"""\
+                pick {prev.parent().oid.short()} commit two
+                pick {prev.parent().parent().oid.short()} commit one
+                pick {prev.oid.short()} commit three
+                """
+            )
+
+    new_commit3 = curr = repo.get_commit("HEAD")
+    new_commit1 = curr_u = curr.parent()
+    new_commit2 = curr_u.parent()
+
+    assert curr != prev
+    assert curr.tree() == index_tree
+    assert new_commit1.message == orig_commit1.message
+    assert new_commit2.message == orig_commit2.message
+    assert new_commit3.message == orig_commit3.message
+
+    assert new_commit2.is_root
+    assert new_commit1.parent() == new_commit2
+    assert new_commit3.parent() == new_commit1
+
+    assert new_commit1.tree().entries[b"file1"] == orig_commit1.tree().entries[b"file1"]
+    assert new_commit2.tree().entries[b"file2"] == orig_commit2.tree().entries[b"file2"]
+    assert new_commit3.tree() == orig_commit3.tree()
+
+
 def test_interactive_fixup(repo):
     bash(
         """


### PR DESCRIPTION
Fixes #81 (_Add `--root` option_).

NOTE: This PR is based on/includes #96 (_cut: Enable splitting root commits_).
This adds the ability to run `git revise -i --root` to revise all commits down to the root commit.