### PR TITLE
test.edit: Async editor

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,5 +1,3 @@
-# pylint: disable=not-context-manager
-
 from gitrevise.odb import Repository
 from .conftest import bash, editor_main
 

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -1,5 +1,3 @@
-# pylint: disable=not-context-manager
-
 import os
 from contextlib import contextmanager
 from typing import (

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,5 +1,3 @@
-# pylint: disable=not-context-manager
-
 from typing import (
     Optional,
     Sequence,

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -1,5 +1,3 @@
-# pylint: disable=not-context-manager
-
 import textwrap
 
 from gitrevise.odb import Repository
@@ -350,7 +348,6 @@ def test_normalize_conflicted_file() -> None:
 def flip_last_two_commits(repo: Repository, ed: Editor) -> None:
     head = repo.get_commit("HEAD")
     with ed.next_file() as f:
-        assert f.indata
         lines = f.indata.splitlines()
         assert lines[0].startswith(b"pick " + head.parent().oid.short().encode())
         assert lines[1].startswith(b"pick " + head.oid.short().encode())

--- a/tests/test_reword.py
+++ b/tests/test_reword.py
@@ -1,5 +1,3 @@
-# pylint: disable=not-context-manager
-
 import textwrap
 import pytest
 from gitrevise.odb import Repository


### PR DESCRIPTION
This simplifies and fixes some race conditions in the editing server by introducing a blocking queue of pending edit requests.

This means that if the launched `git-revise` process invokes the editor before the test invokes `next_file()`, the request will still be picked up from the queue. Previously, this relied on checking an attribute `server.current` which was set in another thread.

This also splits apart `EditorFile` (the mutable/inspectable edit data that the test can manipulate) from the HTTP request handler itself. Beyond separation of those concerns, a side effect is that this fixes pylint's ability to disentangle the expected type of the `next_file` context manager. Previously the mutual modification between `Editor` and `EditorFile` previously forced it to give up. (Although pylint is not enabled in `tests/` in this branch, it is in another).


~Merge resolutions:~
  * ~The resolved  merge of this branch, #116 (_test + pylint…_), and #117 (_test + mypy…_) can be found at [rwe/git-revise@test-mypy-pylint-async-editor](https://github.com/mystor/git-revise/compare/main...rwe:test-mypy-pylint-async-editor?expand=1).~