### PR TITLE
test: use `pathlib.Path` instead of deprecated `py.path`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@
 import pytest
 import shlex
 import os
-import py.path
 import sys
 import tempfile
 import textwrap
 import subprocess
 import traceback
+from pathlib import Path
 from gitrevise.odb import Repository
 from gitrevise.utils import sh_path
 from contextlib import contextmanager
@@ -67,7 +67,7 @@ def repo(hermetic_seal):
 @pytest.fixture
 def short_tmpdir():
     with tempfile.TemporaryDirectory() as tdir:
-        yield py.path.local(tdir)
+        yield Path(tdir)
 
 
 @contextmanager

--- a/tests/test_gpgsign.py
+++ b/tests/test_gpgsign.py
@@ -26,7 +26,7 @@ def test_gpgsign(repo, short_tmpdir, monkeypatch):
         monkeypatch.setenv("GNUPGHOME", str(gnupghome))
 
     gnupghome.chmod(0o700)
-    (gnupghome / "gpg.conf").write("pinentry-mode loopback")
+    (gnupghome / "gpg.conf").write_text("pinentry-mode loopback")
     user_ident = repo.default_author.signing_key
     sh_run(
         ["gpg", "--batch", "--passphrase", "", "--quick-gen-key", user_ident],


### PR DESCRIPTION
`py.path` (via the `py` package) is deprecated and is not even a declared dependency; it's only available coincidentally through a transitive dependency on `tox` itself.

Its documentation recommends just using the standard pathlib.

From note here: https://github.com/mystor/git-revise/pull/94#discussion_r721637493