### PR TITLE
test + pylint: enable pylint in tests/

### DIFF
--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -23,7 +23,7 @@ from .odb import Tree, Blob, Commit, Entry, Mode, Repository
 from .utils import edit_file
 
 
-T = TypeVar("T")  # pylint: disable=C0103
+T = TypeVar("T")  # pylint: disable=invalid-name
 
 
 class MergeConflict(Exception):

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional, Sequence, Tuple
-from subprocess import CompletedProcess, run, CalledProcessError
+from typing import Any, List, Optional, Sequence, Tuple, TYPE_CHECKING
+from subprocess import run, CalledProcessError
 from pathlib import Path
 import textwrap
 import sys
@@ -9,6 +9,10 @@ import os
 import re
 
 from .odb import Repository, Commit, Tree, Oid, Reference
+
+
+if TYPE_CHECKING:
+    from subprocess import CompletedProcess
 
 
 class EditorError(Exception):
@@ -308,7 +312,7 @@ def sh_run(
     cmd: Sequence[Any],
     *args: Any,
     **kwargs: Any,
-) -> CompletedProcess[Any]:
+) -> "CompletedProcess[Any]":
     """Run a command within git's shell environment. This is the same as
     subprocess.run on most platforms, but will enter the git-bash mingw
     environment on Windows."""

--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,11 @@
+[MASTER]
+# Make sure things like "import gitrevise.odb" are resolved to the source
+# when running pylint from the command line or IDE.
+init-hook=
+  import os, sys, pylint.config as plc
+  sys.path.append(os.path.dirname(plc.PYLINTRC))
+
+
 [MESSAGES CONTROL]
 
 disable=
@@ -14,3 +22,13 @@ disable=
     # Currently broken analyses which are also handled (better) by mypy
     class-variable-slots-conflict,
     no-member
+
+good-names=
+  # "Exception as e" is perfectly fine.
+  e,
+  # "with open(…) as f" is idiomatic.
+  f,
+  # Other contextually-unambiguous names.
+  fn,
+  repo,
+  ed

--- a/tests/dummy_editor.py
+++ b/tests/dummy_editor.py
@@ -4,11 +4,10 @@ from urllib.request import urlopen
 
 
 def run_editor(path: Path, url: str) -> None:
-    # pylint: disable=invalid-name
-    with urlopen(url, data=path.read_bytes(), timeout=10) as r:
-        length = int(r.headers.get("content-length"))
-        data = r.read(length)
-        if r.status != 200:
+    with urlopen(url, data=path.read_bytes(), timeout=10) as request:
+        length = int(request.headers.get("content-length"))
+        data = request.read(length)
+        if request.status != 200:
             raise Exception(data.decode())
     path.write_bytes(data)
 

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,6 +1,7 @@
-# pylint: skip-file
+# pylint: disable=not-context-manager
 
-from conftest import *
+from gitrevise.odb import Repository
+from .conftest import bash, editor_main
 
 
 def test_cut(repo: Repository) -> None:

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -3,7 +3,7 @@
 from conftest import *
 
 
-def test_cut(repo):
+def test_cut(repo: Repository) -> None:
     bash(
         """
         echo "Hello, World" >> file1
@@ -46,7 +46,7 @@ def test_cut(repo):
     assert new_uu == prev_uu
 
 
-def test_cut_root(repo):
+def test_cut_root(repo: Repository) -> None:
     bash(
         """
         echo "Hello, World" >> file1

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -1,13 +1,21 @@
-# pylint: skip-file
+# pylint: disable=not-context-manager
 
-from conftest import *
+import os
+from contextlib import contextmanager
+from typing import (
+    Generator,
+    Optional,
+    Sequence,
+)
+import pytest
+from gitrevise.odb import Repository
 from gitrevise.utils import commit_range
 from gitrevise.todo import StepKind, build_todos, autosquash_todos
-import os
+from .conftest import bash, main, editor_main, Editor
 
 
-@pytest.fixture
-def basic_repo(repo: Repository) -> Repository:
+@pytest.fixture(name="basic_repo")
+def fixture_basic_repo(repo: Repository) -> Repository:
     bash(
         """
         cat <<EOF >file1
@@ -337,7 +345,7 @@ def test_fixup_order_transitive(repo: Repository) -> None:
     assert tip.persisted
 
     todos = build_todos(commit_range(old, tip), index=None)
-    [target, a, b, c] = autosquash_todos(todos)
+    [target, a, b, c] = autosquash_todos(todos)  # pylint: disable=invalid-name
 
     assert b"target commit" in target.commit.message
     assert b"1.0" in a.commit.message

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -7,7 +7,7 @@ import os
 
 
 @pytest.fixture
-def basic_repo(repo):
+def basic_repo(repo: Repository) -> Repository:
     bash(
         """
         cat <<EOF >file1
@@ -29,13 +29,23 @@ def basic_repo(repo):
     return repo
 
 
-def fixup_helper(repo, flags, target, message=None):
+def fixup_helper(
+    repo: Repository,
+    flags: Sequence[str],
+    target: str,
+    message: Optional[str] = None,
+) -> None:
     with fixup_helper_editor(repo=repo, flags=flags, target=target, message=message):
         pass
 
 
 @contextmanager
-def fixup_helper_editor(repo, flags, target, message=None):
+def fixup_helper_editor(
+    repo: Repository,
+    flags: Sequence[str],
+    target: str,
+    message: Optional[str] = None,
+) -> Generator[Editor, None, None]:
     old = repo.get_commit(target)
     assert old.persisted
 
@@ -46,7 +56,7 @@ def fixup_helper_editor(repo, flags, target, message=None):
         """
     )
 
-    with editor_main(flags + [target]) as ed:
+    with editor_main((*flags, target)) as ed:
         yield ed
 
     new = repo.get_commit(target)
@@ -65,15 +75,15 @@ def fixup_helper_editor(repo, flags, target, message=None):
     assert new.committer == repo.default_committer, "committer is updated"
 
 
-def test_fixup_head(basic_repo):
+def test_fixup_head(basic_repo: Repository) -> None:
     fixup_helper(basic_repo, [], "HEAD")
 
 
-def test_fixup_nonhead(basic_repo):
+def test_fixup_nonhead(basic_repo: Repository) -> None:
     fixup_helper(basic_repo, [], "HEAD~")
 
 
-def test_fixup_head_msg(basic_repo):
+def test_fixup_head_msg(basic_repo: Repository) -> None:
     fixup_helper(
         basic_repo,
         ["-m", "fixup_head test", "-m", "another line"],
@@ -82,7 +92,7 @@ def test_fixup_head_msg(basic_repo):
     )
 
 
-def test_fixup_nonhead_msg(basic_repo):
+def test_fixup_nonhead_msg(basic_repo: Repository) -> None:
     fixup_helper(
         basic_repo,
         ["-m", "fixup_nonhead test", "-m", "another line"],
@@ -91,7 +101,7 @@ def test_fixup_nonhead_msg(basic_repo):
     )
 
 
-def test_fixup_head_editor(basic_repo):
+def test_fixup_head_editor(basic_repo: Repository) -> None:
     old = basic_repo.get_commit("HEAD")
     newmsg = "fixup_head_editor test\n\nanother line\n"
 
@@ -101,7 +111,7 @@ def test_fixup_head_editor(basic_repo):
             f.replace_dedent(newmsg)
 
 
-def test_fixup_nonhead_editor(basic_repo):
+def test_fixup_nonhead_editor(basic_repo: Repository) -> None:
     old = basic_repo.get_commit("HEAD~")
     newmsg = "fixup_nonhead_editor test\n\nanother line\n"
 
@@ -111,7 +121,7 @@ def test_fixup_nonhead_editor(basic_repo):
             f.replace_dedent(newmsg)
 
 
-def test_fixup_nonhead_conflict(basic_repo):
+def test_fixup_nonhead_conflict(basic_repo: Repository) -> None:
     bash('echo "conflict" > file1')
     bash("git add file1")
 
@@ -151,7 +161,7 @@ def test_fixup_nonhead_conflict(basic_repo):
     assert new != old
 
 
-def test_autosquash_nonhead(repo):
+def test_autosquash_nonhead(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -195,7 +205,7 @@ def test_autosquash_nonhead(repo):
     assert file2 == b"second file\nextra line\n"
 
 
-def test_fixup_of_fixup(repo):
+def test_fixup_of_fixup(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -243,7 +253,7 @@ def test_fixup_of_fixup(repo):
     assert file2 == b"second file\nextra line\neven more\n"
 
 
-def test_fixup_by_id(repo):
+def test_fixup_by_id(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -287,7 +297,7 @@ def test_fixup_by_id(repo):
     assert file2 == b"second file\nextra line\n"
 
 
-def test_fixup_order(repo):
+def test_fixup_order(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -310,7 +320,7 @@ def test_fixup_order(repo):
     assert b"second fixup" in second.commit.message
 
 
-def test_fixup_order_transitive(repo):
+def test_fixup_order_transitive(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -335,7 +345,7 @@ def test_fixup_order_transitive(repo):
     assert b"2.0" in c.commit.message
 
 
-def test_fixup_order_cycle(repo):
+def test_fixup_order_cycle(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -357,7 +367,7 @@ def test_fixup_order_cycle(repo):
     assert all(step.kind == StepKind.PICK for step in new_todos)
 
 
-def test_autosquash_multiline_summary(repo):
+def test_autosquash_multiline_summary(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'initial commit'

--- a/tests/test_gpgsign.py
+++ b/tests/test_gpgsign.py
@@ -5,7 +5,11 @@ from subprocess import CalledProcessError
 from gitrevise.utils import sh_run
 
 
-def test_gpgsign(repo, short_tmpdir, monkeypatch):
+def test_gpgsign(
+    repo: Repository,
+    short_tmpdir: py.path.local,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bash("git commit --allow-empty -m 'commit 1'")
     assert repo.get_commit("HEAD").gpgsig is None
 

--- a/tests/test_gpgsign.py
+++ b/tests/test_gpgsign.py
@@ -1,13 +1,15 @@
-# pylint: skip-file
-
-from conftest import *
+import os
+from pathlib import Path
 from subprocess import CalledProcessError
+import pytest
+from gitrevise.odb import Repository
 from gitrevise.utils import sh_run
+from .conftest import bash, main
 
 
 def test_gpgsign(
     repo: Repository,
-    short_tmpdir: py.path.local,
+    short_tmpdir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     bash("git commit --allow-empty -m 'commit 1'")
@@ -30,7 +32,7 @@ def test_gpgsign(
         monkeypatch.setenv("GNUPGHOME", str(gnupghome))
 
     gnupghome.chmod(0o700)
-    (gnupghome / "gpg.conf").write("pinentry-mode loopback")
+    (gnupghome / "gpg.conf").write_text("pinentry-mode loopback")
     user_ident = repo.default_author.signing_key
     sh_run(
         ["gpg", "--batch", "--passphrase", "", "--quick-gen-key", user_ident],

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,7 +1,17 @@
-# pylint: skip-file
+# pylint: disable=not-context-manager
 
+from typing import (
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+)
 import pytest
-from conftest import *
+from gitrevise.odb import Repository
+from .conftest import bash, editor_main
+
+
+if TYPE_CHECKING:
+    from _typeshed import StrPath
 
 
 def interactive_reorder_helper(repo: Repository, cwd: "StrPath") -> None:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -4,7 +4,7 @@ import pytest
 from conftest import *
 
 
-def interactive_reorder_helper(repo, cwd):
+def interactive_reorder_helper(repo: Repository, cwd: "StrPath") -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -58,16 +58,16 @@ def interactive_reorder_helper(repo, cwd):
     assert prev.tree().entries[b"file1"] == curr_u.tree().entries[b"file1"]
 
 
-def test_interactive_reorder(repo):
+def test_interactive_reorder(repo: Repository) -> None:
     interactive_reorder_helper(repo, cwd=repo.workdir)
 
 
-def test_interactive_reorder_subdir(repo):
+def test_interactive_reorder_subdir(repo: Repository) -> None:
     bash("mkdir subdir")
     interactive_reorder_helper(repo, cwd=repo.workdir / "subdir")
 
 
-def test_interactive_on_root(repo):
+def test_interactive_on_root(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -126,7 +126,7 @@ def test_interactive_on_root(repo):
     assert new_commit3.tree() == orig_commit3.tree()
 
 
-def test_interactive_fixup(repo):
+def test_interactive_fixup(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -210,7 +210,12 @@ def test_interactive_fixup(repo):
         (None, "1", True),
     ],
 )
-def test_autosquash_config(repo, rebase_config, revise_config, expected):
+def test_autosquash_config(
+    repo: Repository,
+    rebase_config: Optional[str],
+    revise_config: Optional[str],
+    expected: bool,
+) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -253,8 +258,8 @@ def test_autosquash_config(repo, rebase_config, revise_config, expected):
 
         """
 
-    def subtest(args, expected_todos):
-        with editor_main(args + ["-i", "HEAD~3"]) as ed:
+    def subtest(args: Sequence[str], expected_todos: str) -> None:
+        with editor_main((*args, "-i", "HEAD~3")) as ed:
             with ed.next_file() as f:
                 assert f.startswith_dedent(expected_todos)
                 f.replace_dedent(disabled)  # don't mutate state
@@ -266,7 +271,7 @@ def test_autosquash_config(repo, rebase_config, revise_config, expected):
     subtest(["--no-autosquash"], disabled)
 
 
-def test_interactive_reword(repo):
+def test_interactive_reword(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -6,7 +6,7 @@ from conftest import *
 from gitrevise.merge import normalize_conflicted_file
 
 
-def history_with_two_conflicting_commits(autoUpdate: bool = False):
+def history_with_two_conflicting_commits(autoUpdate: bool = False) -> None:
     bash(
         f"""
         git config rerere.enabled true
@@ -18,7 +18,7 @@ def history_with_two_conflicting_commits(autoUpdate: bool = False):
     )
 
 
-def test_reuse_recorded_resolution(repo):
+def test_reuse_recorded_resolution(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=True)
 
     with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
@@ -56,7 +56,7 @@ def test_reuse_recorded_resolution(repo):
             f.replace_dedent("resolved one\n")
 
 
-def test_rerere_no_autoupdate(repo):
+def test_rerere_no_autoupdate(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=False)
 
     with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
@@ -96,7 +96,7 @@ def test_rerere_no_autoupdate(repo):
     )
 
 
-def test_rerere_merge(repo):
+def test_rerere_merge(repo: Repository) -> None:
     (repo.workdir / "file").write_bytes(10 * b"x\n")
     bash(
         """
@@ -150,7 +150,7 @@ def test_rerere_merge(repo):
     )
 
 
-def test_replay_resolution_recorded_by_git(repo):
+def test_replay_resolution_recorded_by_git(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=True)
     # Switch the order of the last two commits, recording the conflict
     # resolution with Git itself.
@@ -218,7 +218,7 @@ def test_replay_resolution_recorded_by_git(repo):
     )
 
 
-def test_normalize_conflicted_file():
+def test_normalize_conflicted_file() -> None:
     # Normalize conflict markers and labels.
     assert normalize_conflicted_file(
         dedent(
@@ -346,9 +346,10 @@ def test_normalize_conflicted_file():
     )
 
 
-def flip_last_two_commits(repo: Repository, ed: Editor):
+def flip_last_two_commits(repo: Repository, ed: Editor) -> None:
     head = repo.get_commit("HEAD")
     with ed.next_file() as f:
+        assert f.indata
         lines = f.indata.splitlines()
         assert lines[0].startswith(b"pick " + head.parent().oid.short().encode())
         assert lines[1].startswith(b"pick " + head.oid.short().encode())

--- a/tests/test_reword.py
+++ b/tests/test_reword.py
@@ -6,7 +6,7 @@ from conftest import *
 
 @pytest.mark.parametrize("target", ["HEAD", "HEAD~", "HEAD~~"])
 @pytest.mark.parametrize("use_editor", [True, False])
-def test_reword(repo, target, use_editor):
+def test_reword(repo: Repository, target: str, use_editor: bool) -> None:
     bash(
         """
         echo "hello, world" > file1

--- a/tests/test_reword.py
+++ b/tests/test_reword.py
@@ -1,7 +1,9 @@
-# pylint: skip-file
+# pylint: disable=not-context-manager
 
 import textwrap
-from conftest import *
+import pytest
+from gitrevise.odb import Repository
+from .conftest import bash, main, editor_main
 
 
 @pytest.mark.parametrize("target", ["HEAD", "HEAD~", "HEAD~~"])

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,11 @@ deps =
 
 [testenv:lint]
 description = lint with pylint
-commands = pylint gitrevise {posargs}
+commands = pylint gitrevise tests {posargs}
 basepython = python3.10
-deps = pylint >= 2.4
+deps =
+    {[testenv]deps}
+    pylint >= 2.4
 
 [testenv:format]
 description = validate formatting

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,11 @@ passenv = PROGRAMFILES*  # to locate git-bash on windows
 
 [testenv:mypy]
 description = typecheck with mypy
-commands = mypy gitrevise {posargs}
+commands = mypy gitrevise tests {posargs}
 basepython = python3.10
-deps = mypy
+deps =
+    {[testenv]deps}
+    mypy
 
 [testenv:lint]
 description = lint with pylint


### PR DESCRIPTION
This enables `pylint` to be run in the `tests/` directory and fixes or suppresses the lint errors there.

NOTE: This _includes_ the following two minor PRs, which are split out for convenience:
  * [ ] #114 (_test: use `pathlib.Path` instead of deprecated `py.path`_)
  * [ ] #115 (_py38: sh_run: `CompletedProcess[Any]` not recognized by pylint_)

Merging this PR would auto-close those ones; or they can be merged individually.

The remaining `not-context-manager` suppression would be resolved by the changes in #113 (_Async test editor_), but that change is not included here.

Merge resolutions:
  * (*EDIT*: Now included here, since #117 is merged). ~The resolved merge of this branch + #117 (_test + mypy: enable mypy in tests/_) can be found at [rwe/git-revise@test-mypy-pylint](https://github.com/mystor/git-revise/compare/main...rwe:test-mypy-pylint?expand=1).~
  * The resolved  merge of this branch, #117 (_test + mypy…_) and #113 (_test.edit: Async editor_) can be found at [rwe/git-revise@test-mypy-pylint-async-editor](https://github.com/mystor/git-revise/compare/main...rwe:test-mypy-pylint-async-editor?expand=1).