### PR TITLE
test + mypy: enable mypy in tests/

### DIFF
--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -3,7 +3,7 @@
 from conftest import *
 
 
-def test_cut(repo):
+def test_cut(repo: Repository) -> None:
     bash(
         """
         echo "Hello, World" >> file1
@@ -46,7 +46,7 @@ def test_cut(repo):
     assert new_uu == prev_uu
 
 
-def test_cut_root(repo):
+def test_cut_root(repo: Repository) -> None:
     bash(
         """
         echo "Hello, World" >> file1

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -7,7 +7,7 @@ import os
 
 
 @pytest.fixture
-def basic_repo(repo):
+def basic_repo(repo: Repository) -> Repository:
     bash(
         """
         cat <<EOF >file1
@@ -29,13 +29,23 @@ def basic_repo(repo):
     return repo
 
 
-def fixup_helper(repo, flags, target, message=None):
+def fixup_helper(
+    repo: Repository,
+    flags: Sequence[str],
+    target: str,
+    message: Optional[str] = None,
+) -> None:
     with fixup_helper_editor(repo=repo, flags=flags, target=target, message=message):
         pass
 
 
 @contextmanager
-def fixup_helper_editor(repo, flags, target, message=None):
+def fixup_helper_editor(
+    repo: Repository,
+    flags: Sequence[str],
+    target: str,
+    message: Optional[str] = None,
+) -> Generator[Editor, None, None]:
     old = repo.get_commit(target)
     assert old.persisted
 
@@ -46,7 +56,7 @@ def fixup_helper_editor(repo, flags, target, message=None):
         """
     )
 
-    with editor_main(flags + [target]) as ed:
+    with editor_main((*flags, target)) as ed:
         yield ed
 
     new = repo.get_commit(target)
@@ -65,15 +75,15 @@ def fixup_helper_editor(repo, flags, target, message=None):
     assert new.committer == repo.default_committer, "committer is updated"
 
 
-def test_fixup_head(basic_repo):
+def test_fixup_head(basic_repo: Repository) -> None:
     fixup_helper(basic_repo, [], "HEAD")
 
 
-def test_fixup_nonhead(basic_repo):
+def test_fixup_nonhead(basic_repo: Repository) -> None:
     fixup_helper(basic_repo, [], "HEAD~")
 
 
-def test_fixup_head_msg(basic_repo):
+def test_fixup_head_msg(basic_repo: Repository) -> None:
     fixup_helper(
         basic_repo,
         ["-m", "fixup_head test", "-m", "another line"],
@@ -82,7 +92,7 @@ def test_fixup_head_msg(basic_repo):
     )
 
 
-def test_fixup_nonhead_msg(basic_repo):
+def test_fixup_nonhead_msg(basic_repo: Repository) -> None:
     fixup_helper(
         basic_repo,
         ["-m", "fixup_nonhead test", "-m", "another line"],
@@ -91,7 +101,7 @@ def test_fixup_nonhead_msg(basic_repo):
     )
 
 
-def test_fixup_head_editor(basic_repo):
+def test_fixup_head_editor(basic_repo: Repository) -> None:
     old = basic_repo.get_commit("HEAD")
     newmsg = "fixup_head_editor test\n\nanother line\n"
 
@@ -101,7 +111,7 @@ def test_fixup_head_editor(basic_repo):
             f.replace_dedent(newmsg)
 
 
-def test_fixup_nonhead_editor(basic_repo):
+def test_fixup_nonhead_editor(basic_repo: Repository) -> None:
     old = basic_repo.get_commit("HEAD~")
     newmsg = "fixup_nonhead_editor test\n\nanother line\n"
 
@@ -111,7 +121,7 @@ def test_fixup_nonhead_editor(basic_repo):
             f.replace_dedent(newmsg)
 
 
-def test_fixup_nonhead_conflict(basic_repo):
+def test_fixup_nonhead_conflict(basic_repo: Repository) -> None:
     bash('echo "conflict" > file1')
     bash("git add file1")
 
@@ -151,7 +161,7 @@ def test_fixup_nonhead_conflict(basic_repo):
     assert new != old
 
 
-def test_autosquash_nonhead(repo):
+def test_autosquash_nonhead(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -195,7 +205,7 @@ def test_autosquash_nonhead(repo):
     assert file2 == b"second file\nextra line\n"
 
 
-def test_fixup_of_fixup(repo):
+def test_fixup_of_fixup(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -243,7 +253,7 @@ def test_fixup_of_fixup(repo):
     assert file2 == b"second file\nextra line\neven more\n"
 
 
-def test_fixup_by_id(repo):
+def test_fixup_by_id(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -287,7 +297,7 @@ def test_fixup_by_id(repo):
     assert file2 == b"second file\nextra line\n"
 
 
-def test_fixup_order(repo):
+def test_fixup_order(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -310,7 +320,7 @@ def test_fixup_order(repo):
     assert b"second fixup" in second.commit.message
 
 
-def test_fixup_order_transitive(repo):
+def test_fixup_order_transitive(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -335,7 +345,7 @@ def test_fixup_order_transitive(repo):
     assert b"2.0" in c.commit.message
 
 
-def test_fixup_order_cycle(repo):
+def test_fixup_order_cycle(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'old'
@@ -357,7 +367,7 @@ def test_fixup_order_cycle(repo):
     assert all(step.kind == StepKind.PICK for step in new_todos)
 
 
-def test_autosquash_multiline_summary(repo):
+def test_autosquash_multiline_summary(repo: Repository) -> None:
     bash(
         """
         git commit --allow-empty -m 'initial commit'

--- a/tests/test_gpgsign.py
+++ b/tests/test_gpgsign.py
@@ -5,7 +5,11 @@ from subprocess import CalledProcessError
 from gitrevise.utils import sh_run
 
 
-def test_gpgsign(repo, short_tmpdir, monkeypatch):
+def test_gpgsign(
+    repo: Repository,
+    short_tmpdir: py.path.local,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bash("git commit --allow-empty -m 'commit 1'")
     assert repo.get_commit("HEAD").gpgsig is None
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -4,7 +4,7 @@ import pytest
 from conftest import *
 
 
-def interactive_reorder_helper(repo, cwd):
+def interactive_reorder_helper(repo: Repository, cwd: "StrPath") -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -58,16 +58,16 @@ def interactive_reorder_helper(repo, cwd):
     assert prev.tree().entries[b"file1"] == curr_u.tree().entries[b"file1"]
 
 
-def test_interactive_reorder(repo):
+def test_interactive_reorder(repo: Repository) -> None:
     interactive_reorder_helper(repo, cwd=repo.workdir)
 
 
-def test_interactive_reorder_subdir(repo):
+def test_interactive_reorder_subdir(repo: Repository) -> None:
     bash("mkdir subdir")
     interactive_reorder_helper(repo, cwd=repo.workdir / "subdir")
 
 
-def test_interactive_on_root(repo):
+def test_interactive_on_root(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -126,7 +126,7 @@ def test_interactive_on_root(repo):
     assert new_commit3.tree() == orig_commit3.tree()
 
 
-def test_interactive_fixup(repo):
+def test_interactive_fixup(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -210,7 +210,12 @@ def test_interactive_fixup(repo):
         (None, "1", True),
     ],
 )
-def test_autosquash_config(repo, rebase_config, revise_config, expected):
+def test_autosquash_config(
+    repo: Repository,
+    rebase_config: Optional[str],
+    revise_config: Optional[str],
+    expected: bool,
+) -> None:
     bash(
         """
         echo "hello, world" > file1
@@ -253,8 +258,8 @@ def test_autosquash_config(repo, rebase_config, revise_config, expected):
 
         """
 
-    def subtest(args, expected_todos):
-        with editor_main(args + ["-i", "HEAD~3"]) as ed:
+    def subtest(args: Sequence[str], expected_todos: str) -> None:
+        with editor_main((*args, "-i", "HEAD~3")) as ed:
             with ed.next_file() as f:
                 assert f.startswith_dedent(expected_todos)
                 f.replace_dedent(disabled)  # don't mutate state
@@ -266,7 +271,7 @@ def test_autosquash_config(repo, rebase_config, revise_config, expected):
     subtest(["--no-autosquash"], disabled)
 
 
-def test_interactive_reword(repo):
+def test_interactive_reword(repo: Repository) -> None:
     bash(
         """
         echo "hello, world" > file1

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -6,7 +6,7 @@ from conftest import *
 from gitrevise.merge import normalize_conflicted_file
 
 
-def history_with_two_conflicting_commits(autoUpdate: bool = False):
+def history_with_two_conflicting_commits(autoUpdate: bool = False) -> None:
     bash(
         f"""
         git config rerere.enabled true
@@ -18,7 +18,7 @@ def history_with_two_conflicting_commits(autoUpdate: bool = False):
     )
 
 
-def test_reuse_recorded_resolution(repo):
+def test_reuse_recorded_resolution(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=True)
 
     with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
@@ -56,7 +56,7 @@ def test_reuse_recorded_resolution(repo):
             f.replace_dedent("resolved one\n")
 
 
-def test_rerere_no_autoupdate(repo):
+def test_rerere_no_autoupdate(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=False)
 
     with editor_main(("-i", "HEAD~~"), input=b"y\ny\ny\ny\n") as ed:
@@ -96,7 +96,7 @@ def test_rerere_no_autoupdate(repo):
     )
 
 
-def test_rerere_merge(repo):
+def test_rerere_merge(repo: Repository) -> None:
     (repo.workdir / "file").write_bytes(10 * b"x\n")
     bash(
         """
@@ -150,7 +150,7 @@ def test_rerere_merge(repo):
     )
 
 
-def test_replay_resolution_recorded_by_git(repo):
+def test_replay_resolution_recorded_by_git(repo: Repository) -> None:
     history_with_two_conflicting_commits(autoUpdate=True)
     # Switch the order of the last two commits, recording the conflict
     # resolution with Git itself.
@@ -218,7 +218,7 @@ def test_replay_resolution_recorded_by_git(repo):
     )
 
 
-def test_normalize_conflicted_file():
+def test_normalize_conflicted_file() -> None:
     # Normalize conflict markers and labels.
     assert normalize_conflicted_file(
         dedent(
@@ -346,9 +346,10 @@ def test_normalize_conflicted_file():
     )
 
 
-def flip_last_two_commits(repo: Repository, ed: Editor):
+def flip_last_two_commits(repo: Repository, ed: Editor) -> None:
     head = repo.get_commit("HEAD")
     with ed.next_file() as f:
+        assert f.indata
         lines = f.indata.splitlines()
         assert lines[0].startswith(b"pick " + head.parent().oid.short().encode())
         assert lines[1].startswith(b"pick " + head.oid.short().encode())

--- a/tests/test_reword.py
+++ b/tests/test_reword.py
@@ -6,7 +6,7 @@ from conftest import *
 
 @pytest.mark.parametrize("target", ["HEAD", "HEAD~", "HEAD~~"])
 @pytest.mark.parametrize("use_editor", [True, False])
-def test_reword(repo, target, use_editor):
+def test_reword(repo: Repository, target: str, use_editor: bool) -> None:
     bash(
         """
         echo "hello, world" > file1

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,11 @@ passenv = PROGRAMFILES*  # to locate git-bash on windows
 
 [testenv:mypy]
 description = typecheck with mypy
-commands = mypy gitrevise {posargs}
+commands = mypy gitrevise tests {posargs}
 basepython = python3.10
-deps = mypy
+deps =
+    {[testenv]deps}
+    mypy
 
 [testenv:lint]
 description = lint with pylint


### PR DESCRIPTION
This enables `mypy` to run in `tests/`, and fixes a few minor nits surfaced by that.

Merge resolutions:
  * The resolved merge of this branch + #116 (_test + pylint: enable pylint in tests/_) can be found at [rwe/git-revise@test-mypy-pylint](https://github.com/mystor/git-revise/compare/main...rwe:test-mypy-pylint?expand=1).
  * The resolved  merge of this branch, #116 (_test + pylint…_) and #113 (_test.edit: Async editor_) can be found at [rwe/git-revise@test-mypy-pylint-async-editor](https://github.com/mystor/git-revise/compare/main...rwe:test-mypy-pylint-async-editor?expand=1).