### PR TITLE
edit: Run editor from cwd, not parent of file

### DIFF
--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -45,7 +45,7 @@ def rebase(commit: Commit, new_parent: Optional[Commit]) -> Commit:
         return cmt.tree() if cmt is not None else Tree(repo, b"")
 
     tree = merge_trees(
-        Path("/"),
+        Path(),
         (get_summary(new_parent), get_summary(orig_parent), get_summary(commit)),
         get_tree(new_parent),
         get_tree(orig_parent),
@@ -237,7 +237,7 @@ def merge_blobs(
 
     # Open the editor on the conflicted file. We ensure the relative path
     # matches the path of the original file for a better editor experience.
-    conflicts = tmpdir / "conflict" / path.relative_to("/")
+    conflicts = tmpdir / "conflict" / path
     conflicts.parent.mkdir(parents=True, exist_ok=True)
     conflicts.write_bytes(preimage)
     merged = edit_file(repo, conflicts)

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -66,8 +66,8 @@ def local_commits(repo: Repository, tip: Commit) -> Tuple[Commit, List[Commit]]:
 
 def edit_file_with_editor(editor: str, path: Path) -> bytes:
     try:
-        cmd = [sh_path(), "-ec", f'{editor} "$@"', editor, path.name]
-        run(cmd, check=True, cwd=path.parent)
+        cmd = [sh_path(), "-ec", f'{editor} "$@"', editor, str(path)]
+        run(cmd, check=True)
     except CalledProcessError as err:
         raise EditorError(f"Editor exited with status {err}") from err
     return path.read_bytes()

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 from typing import (
     Generator,
@@ -137,27 +136,27 @@ def test_fixup_nonhead_conflict(basic_repo: Repository) -> None:
     with editor_main(["HEAD~"], input=b"y\ny\ny\ny\n") as ed:
         with ed.next_file() as f:
             assert f.equals_dedent(
-                f"""\
-                <<<<<<< {os.sep}file1 (new parent): commit1
+                """\
+                <<<<<<< file1 (new parent): commit1
                 Hello, World!
                 How are things?
                 =======
                 conflict
-                >>>>>>> {os.sep}file1 (current): <git index>
+                >>>>>>> file1 (current): <git index>
                 """
             )
             f.replace_dedent("conflict1\n")
 
         with ed.next_file() as f:
             assert f.equals_dedent(
-                f"""\
-                <<<<<<< {os.sep}file1 (new parent): commit1
+                """\
+                <<<<<<< file1 (new parent): commit1
                 conflict1
                 =======
                 Hello, World!
                 Oops, gotta add a new line!
                 How are things?
-                >>>>>>> {os.sep}file1 (current): commit2
+                >>>>>>> file1 (current): commit2
                 """
             )
             f.replace_dedent("conflict2\n")


### PR DESCRIPTION
This includes two minor commits to improve treatment of editor + paths, consistent with with `git-rebase` behaviour:

* The editor is launched from `cwd` rather than the arbitrary parent directory of a file. This means when editing `git-revise-todo`, for example, you can open/save/etc other local files rather than starting in a random temp dir. This is consistent with how the editor is launched for `git-rebase-todo`.
* When merging, file paths are shown as relative to the repo root, *not* relative to a phony filesystem root (`/`). In combination with the above, this means that the displayed path in diff/merge markers (e.g. `<<<<<<< file1 (new parent)`) are likely the correct path relative to the editor, making it easier to reference with typical "open file at this path" editor commands. (Versus `/file` which would typically never exist).