### PR TITLE
lint: use `isort` to normalize import order

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,8 +5,8 @@ Running Tests
 -------------
 
 :command:`tox` is used to run tests. It will run :command:`mypy` for type
-checking, :command:`pylint` for linting, :command:`pytest` for testing, and
-:command:`black` for code formatting.
+checking, :command:`isort` and :command:`pylint` for linting, :command:`pytest`
+for testing, and :command:`black` for code formatting.
 
 .. code-block:: shell
 
@@ -22,10 +22,11 @@ checking, :command:`pylint` for linting, :command:`pytest` for testing, and
 Code Formatting
 ---------------
 
-This project uses ``black`` for code formatting.
+This project uses ``isort`` and ``black`` for code formatting.
 
 .. code-block:: shell
 
+  $ isort .  # sort imports
   $ black .  # format all python code
 
 Building Documentation

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -16,8 +16,8 @@ checking, :command:`pylint` for linting, :command:`pytest` for testing, and
   $ tox -e py310  # Python 3.10
   
   $ tox -e mypy   # Mypy Typechecking
-  $ tox -e pylint # Linting
-  $ tox -e black  # Check Formatting
+  $ tox -e lint   # Linting
+  $ tox -e format # Check Formatting
 
 Code Formatting
 ---------------

--- a/gitrevise/merge.py
+++ b/gitrevise/merge.py
@@ -12,16 +12,15 @@ unmodified trees and blobs when possible.
 
 from __future__ import annotations
 
-from typing import Iterator, Optional, Tuple, TypeVar
-from pathlib import Path
-from subprocess import CalledProcessError
 import hashlib
 import os
 import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import Iterator, Optional, Tuple, TypeVar
 
-from .odb import Tree, Blob, Commit, Entry, Mode, Repository
+from .odb import Blob, Commit, Entry, Mode, Repository, Tree
 from .utils import edit_file
-
 
 T = TypeVar("T")  # pylint: disable=invalid-name
 

--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -5,29 +5,28 @@ Helper classes for reading cached objects from Git's Object Database.
 from __future__ import annotations
 
 import hashlib
-import re
 import os
+import re
+import sys
+from collections import defaultdict
+from enum import Enum
+from pathlib import Path
+from subprocess import DEVNULL, PIPE, CalledProcessError, Popen, run
+from tempfile import TemporaryDirectory
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
-    TypeVar,
-    Type,
     Dict,
-    Union,
-    Sequence,
-    Optional,
-    Mapping,
     Generic,
+    Mapping,
+    Optional,
+    Sequence,
     Tuple,
+    Type,
+    TypeVar,
+    Union,
     cast,
 )
-import sys
-from types import TracebackType
-from pathlib import Path
-from enum import Enum
-from subprocess import DEVNULL, Popen, run, PIPE, CalledProcessError
-from collections import defaultdict
-from tempfile import TemporaryDirectory
-
 
 if TYPE_CHECKING:
     from subprocess import _FILE

--- a/gitrevise/todo.py
+++ b/gitrevise/todo.py
@@ -4,8 +4,8 @@ import re
 from enum import Enum
 from typing import List, Optional
 
-from .odb import Commit, Repository, MissingObject
-from .utils import run_editor, run_sequence_editor, edit_commit_message, cut_commit
+from .odb import Commit, MissingObject, Repository
+from .utils import cut_commit, edit_commit_message, run_editor, run_sequence_editor
 
 
 class StepKind(Enum):

--- a/gitrevise/tui.py
+++ b/gitrevise/tui.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-from typing import Optional, List
+import sys
 from argparse import ArgumentParser, Namespace
 from subprocess import CalledProcessError
-import sys
+from typing import List, Optional
 
-from .odb import Repository, Commit, Reference
+from . import __version__
+from .merge import MergeConflict
+from .odb import Commit, Reference, Repository
+from .todo import apply_todos, autosquash_todos, build_todos, edit_todos
 from .utils import (
     EditorError,
     commit_range,
-    edit_commit_message,
-    update_head,
     cut_commit,
+    edit_commit_message,
     local_commits,
+    update_head,
 )
-from .todo import apply_todos, build_todos, edit_todos, autosquash_todos
-from .merge import MergeConflict
-from . import __version__
 
 
 def build_parser() -> ArgumentParser:

--- a/gitrevise/utils.py
+++ b/gitrevise/utils.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional, Sequence, Tuple, TYPE_CHECKING
-from subprocess import run, CalledProcessError
-from pathlib import Path
-import textwrap
-import sys
 import os
 import re
+import sys
+import textwrap
+from pathlib import Path
+from subprocess import CalledProcessError, run
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple
 
-from .odb import Repository, Commit, Tree, Oid, Reference
-
+from .odb import Commit, Oid, Reference, Repository, Tree
 
 if TYPE_CHECKING:
     from subprocess import CompletedProcess

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from setuptools import setup
 
 import gitrevise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import sys
 import tempfile
 import textwrap
 import traceback
-
 from concurrent.futures import CancelledError, Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -14,25 +13,19 @@ from pathlib import Path
 from queue import Empty, Queue
 from threading import Thread
 from types import TracebackType
-from typing import (
-    Generator,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-    TYPE_CHECKING,
-)
+from typing import TYPE_CHECKING, Generator, Optional, Sequence, Type, Union
 
 import pytest
 
 from gitrevise.odb import Repository
 from gitrevise.utils import sh_path
+
 from . import dummy_editor
 
-
 if TYPE_CHECKING:
-    from _typeshed import StrPath
     from typing import Any, Tuple
+
+    from _typeshed import StrPath
 
 
 @pytest.fixture(name="hermetic_seal", autouse=True)

--- a/tests/test_cut.py
+++ b/tests/test_cut.py
@@ -1,4 +1,5 @@
 from gitrevise.odb import Repository
+
 from .conftest import bash, editor_main
 
 

--- a/tests/test_fixup.py
+++ b/tests/test_fixup.py
@@ -1,15 +1,14 @@
 import os
 from contextlib import contextmanager
-from typing import (
-    Generator,
-    Optional,
-    Sequence,
-)
+from typing import Generator, Optional, Sequence
+
 import pytest
+
 from gitrevise.odb import Repository
+from gitrevise.todo import StepKind, autosquash_todos, build_todos
 from gitrevise.utils import commit_range
-from gitrevise.todo import StepKind, build_todos, autosquash_todos
-from .conftest import bash, main, editor_main, Editor
+
+from .conftest import Editor, bash, editor_main, main
 
 
 @pytest.fixture(name="basic_repo")

--- a/tests/test_gpgsign.py
+++ b/tests/test_gpgsign.py
@@ -1,9 +1,12 @@
 import os
 from pathlib import Path
 from subprocess import CalledProcessError
+
 import pytest
+
 from gitrevise.odb import Repository
 from gitrevise.utils import sh_run
+
 from .conftest import bash, main
 
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,12 +1,10 @@
-from typing import (
-    Optional,
-    Sequence,
-    TYPE_CHECKING,
-)
-import pytest
-from gitrevise.odb import Repository
-from .conftest import bash, editor_main
+from typing import TYPE_CHECKING, Optional, Sequence
 
+import pytest
+
+from gitrevise.odb import Repository
+
+from .conftest import bash, editor_main
 
 if TYPE_CHECKING:
     from _typeshed import StrPath

--- a/tests/test_rerere.py
+++ b/tests/test_rerere.py
@@ -1,8 +1,9 @@
 import textwrap
 
-from gitrevise.odb import Repository
 from gitrevise.merge import normalize_conflicted_file
-from .conftest import bash, changeline, main, editor_main, Editor
+from gitrevise.odb import Repository
+
+from .conftest import Editor, bash, changeline, editor_main, main
 
 
 def history_with_two_conflicting_commits(auto_update: bool = False) -> None:

--- a/tests/test_reword.py
+++ b/tests/test_reword.py
@@ -1,7 +1,10 @@
 import textwrap
+
 import pytest
+
 from gitrevise.odb import Repository
-from .conftest import bash, main, editor_main
+
+from .conftest import bash, editor_main, main
 
 
 @pytest.mark.parametrize("target", ["HEAD", "HEAD~", "HEAD~~"])

--- a/tox.ini
+++ b/tox.ini
@@ -29,11 +29,14 @@ deps =
     mypy
 
 [testenv:lint]
-description = lint with pylint
-commands = pylint gitrevise tests {posargs}
+description = lint with pylint and isort
+commands =
+    isort --check gitrevise tests
+    pylint gitrevise tests {posargs}
 basepython = python3.10
 deps =
     {[testenv]deps}
+    isort >= 5.0
     pylint >= 2.4
 
 [testenv:format]


### PR DESCRIPTION
Note that `pylint` already depends on `isort`.

Using it makes import sorting unambiguous and automatic, which helps reduce cognitive load merging various branches in this codebase.

It was a little ambiguous whether it should be in the "lint" or "format" `tox` command, or another one altogether. It's included in "lint" here, because pylint already uses isort internally to catch coarse-grained "wrong-import-order" warnings.

This also updates the `contributing.rst` which referred to some incorrect tox commands.