### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/gitrevise/odb.py
+++ b/gitrevise/odb.py
@@ -222,7 +222,7 @@ class Repository:
         self,
         *cmd: str,
         cwd: Optional[Path] = None,
-        env: Dict[str, str] = None,
+        env: Optional[Dict[str, str]] = None,
         stdin: Optional[bytes] = None,
         stdout: _FILE = PIPE,
         trim_newline: bool = True,

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.8
 warn_return_any = True
 warn_unused_configs = True
+no_implicit_optional = True
 
 # strict typing
 strict_optional = True


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401