### PR TITLE
test: fix CI failures due to pylint changes

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -9,7 +9,6 @@ init-hook=
 [MESSAGES CONTROL]
 
 disable=
-    bad-continuation,
     missing-docstring,
     too-many-arguments,
     too-many-branches,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,7 @@ class EditorFileRequestHandler(BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length"))
         in_data = self.rfile.read(length)
 
+        status, out_data = 500, b"no traceback"
         try:
             # The request is ready. Tell our server, and wait for a reply.
             status, out_data = 200, self.server.await_edit(in_data)

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ envlist =
 description = pytest for {basepython}
 commands = pytest {posargs}
 deps =
-    pytest
-    pytest-xdist
+    pytest ~= 7.1.2
+    pytest-xdist ~= 2.5.0
 passenv = PROGRAMFILES*  # to locate git-bash on windows
 
 [testenv:mypy]
@@ -26,7 +26,7 @@ commands = mypy gitrevise tests {posargs}
 basepython = python3.10
 deps =
     {[testenv]deps}
-    mypy
+    mypy ~= 0.971
 
 [testenv:lint]
 description = lint with pylint
@@ -34,13 +34,13 @@ commands = pylint gitrevise tests {posargs}
 basepython = python3.10
 deps =
     {[testenv]deps}
-    pylint >= 2.4
+    pylint ~= 2.14.5
 
 [testenv:format]
 description = validate formatting
 commands = black --check . {posargs}
 basepython = python3.10
-deps = black
+deps = black ~= 22.6.0
 
 [gh-actions]
 python =


### PR DESCRIPTION
This patch also more aggressively specifies versions for test-only
dependencies to avoid accidental CI failures due to mypy, pylint, or
black updating.