### PR TITLE
Workaround reflog corruption bug in git 2.48

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox


### PR DESCRIPTION
In git 2.48, there is an issue where using `git update-ref` add a new entry to the reflog for a branch will cause corrupted reflog entries to be created for any symbolic refs referencing the updated reference. This impacts most usage of `git-revise`, as we update the default `HEAD` reference indirectly due to using `git rev-parse --symbolic-full-name` to resolve the identity of a branch.

This patch works around this issue in the common case by checking if the given name directly names a valid ref or symbolic ref, skipping the `--symbolic-full-name` resolution if it does. This means that HEAD will be directly updated by `git update-ref`, and receive valid reflog entries.

This workaround shouldn't negatively impact other git versions, and is largely an internal change to how symbolic refs are handled by the odb.Reference type.

See #138 for details.