### PR TITLE
Use `uv` in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      pip-packages:
+      python-packages:
         patterns:
           - "*"


### PR DESCRIPTION
This is a new feature that appeared after #141.